### PR TITLE
Implement RSC migration patterns

### DIFF
--- a/.dev-services.yml.example
+++ b/.dev-services.yml.example
@@ -1,0 +1,76 @@
+# Service Dependencies Configuration
+#
+# This file defines external services that must be running before bin/dev starts.
+# Copy this file to .dev-services.yml and customize for your application.
+#
+# bin/dev will check each service before starting the development server.
+# If any service is not running, it will display helpful error messages with
+# instructions on how to start the service.
+#
+# ⚠️  SECURITY WARNING:
+# Commands in this file are executed during bin/dev startup. Only add commands
+# from trusted sources. This file should not be committed if it contains
+# sensitive information or custom paths specific to your machine. Consider
+# adding .dev-services.yml to .gitignore if it contains machine-specific config.
+#
+# Security best practices:
+# - Commands are executed without shell expansion (shell metacharacters won't work)
+# - Use simple, single commands (e.g., "redis-cli ping", "pg_isready")
+# - Do NOT use shell features: &&, ||, |, $, ;, backticks, etc. will fail
+# - Only include services you trust
+# - Keep commands simple and focused on service health checks
+# - Consider adding .dev-services.yml to .gitignore (commit .example instead)
+#
+# Example configuration:
+#
+# services:
+#   redis:
+#     check_command: "redis-cli ping"
+#     expected_output: "PONG"
+#     start_command: "redis-server"
+#     install_hint: "brew install redis (macOS) or apt-get install redis-server (Linux)"
+#     description: "Redis (for caching and background jobs)"
+#
+#   postgresql:
+#     check_command: "pg_isready"
+#     expected_output: "accepting connections"
+#     start_command: "pg_ctl -D /usr/local/var/postgres start"
+#     install_hint: "brew install postgresql (macOS) or apt-get install postgresql (Linux)"
+#     description: "PostgreSQL database"
+#
+#   elasticsearch:
+#     check_command: "curl -s http://localhost:9200"
+#     expected_output: "cluster_name"
+#     start_command: "brew services start elasticsearch-full"
+#     install_hint: "brew install elasticsearch-full"
+#     description: "Elasticsearch (for search)"
+#
+# Field descriptions:
+#   check_command:    Shell command to check if service is running (required)
+#   expected_output:  String that must appear in command output (optional)
+#   start_command:    Command to start the service (shown in error messages)
+#   install_hint:     How to install the service if not found
+#   description:      Human-readable description of the service
+#
+# To use this file:
+# 1. Copy to .dev-services.yml: cp .dev-services.yml.example .dev-services.yml
+# 2. Uncomment and configure the services your app needs
+# 3. Add .dev-services.yml to .gitignore if it contains sensitive info
+# 4. Run bin/dev - it will check services before starting
+
+services:
+  # Uncomment and configure the services your application requires:
+
+  # redis:
+  #   check_command: "redis-cli ping"
+  #   expected_output: "PONG"
+  #   start_command: "redis-server"
+  #   install_hint: "brew install redis (macOS) or apt-get install redis-server (Linux)"
+  #   description: "Redis (for caching and background jobs)"
+
+  # postgresql:
+  #   check_command: "pg_isready"
+  #   expected_output: "accepting connections"
+  #   start_command: "pg_ctl -D /usr/local/var/postgres start"  # macOS; Linux: sudo service postgresql start
+  #   install_hint: "brew install postgresql (macOS) or apt-get install postgresql (Linux)"
+  #   description: "PostgreSQL database"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Ruby / Rails
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+/storage/*
+!/storage/.keep
+/db/*.sqlite3
+/db/*.sqlite3-journal
+
+# Bundler
+/vendor/bundle
+
+# Node
+/node_modules/
+package-lock.json
+
+# Webpack / Shakapacker build output
+/public/packs/
+/public/packs-test/
+/ssr-generated/
+/.node-renderer-bundles/
+
+# Generated files (auto_load_bundle / shakapacker-precompile-hook)
+/app/javascript/generated/
+/app/javascript/packs/generated/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Bootsnap cache
+/tmp/cache/bootsnap/
+
+# Master key
+/config/master.key
+/config/credentials/*.key

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,11 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
+gem "connection_pool", "~> 2.5"
+
+gem "react_on_rails", path: "/mnt/ssd/react_on_rails-2459-rsc-migration/react_on_rails"
+gem "react_on_rails_pro", path: "/mnt/ssd/react_on_rails-2459-rsc-migration/react_on_rails_pro"
+gem "shakapacker", "~> 9.3"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,28 @@
+PATH
+  remote: /mnt/ssd/react_on_rails-2459-rsc-migration/react_on_rails_pro
+  specs:
+    react_on_rails_pro (16.4.0.rc.3)
+      addressable
+      async (>= 2.6)
+      connection_pool
+      execjs (~> 2.9)
+      http-2 (>= 1.1.1)
+      httpx (~> 1.5)
+      jwt (~> 2.7)
+      rainbow
+      react_on_rails (= 16.4.0.rc.3)
+
+PATH
+  remote: /mnt/ssd/react_on_rails-2459-rsc-migration/react_on_rails
+  specs:
+    react_on_rails (16.4.0.rc.3)
+      addressable
+      connection_pool
+      execjs (~> 2.5)
+      rails (>= 5.2)
+      rainbow (~> 3.0)
+      shakapacker (>= 6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -77,6 +102,12 @@ GEM
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    async (2.36.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (4.0.1)
@@ -97,7 +128,11 @@ GEM
       xpath (~> 3.2)
     cgi (0.5.1)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
+    console (1.34.3)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     crass (1.0.6)
     date (3.5.1)
     debug (1.11.1)
@@ -106,8 +141,16 @@ GEM
     drb (2.2.3)
     erb (6.0.1)
     erubi (1.13.1)
+    execjs (2.10.0)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    http-2 (1.1.2)
+    httpx (1.7.2)
+      http-2 (>= 1.0.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -115,12 +158,15 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
+    io-event (1.14.2)
     irb (1.17.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.18.1)
+    jwt (2.10.2)
+      base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -135,6 +181,7 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.3)
+    metrics (0.15.0)
     mini_mime (1.1.5)
     minitest (6.0.1)
       prism (~> 1.5)
@@ -165,6 +212,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-musl)
       racc (~> 1.4)
+    package_json (0.2.0)
     parallel (1.27.0)
     parser (3.3.10.2)
       ast (~> 2.4.1)
@@ -181,6 +229,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)
+    rack-proxy (0.7.7)
+      rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -266,6 +316,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    semantic_range (3.1.0)
+    shakapacker (9.5.0)
+      activesupport (>= 5.2)
+      package_json
+      rack-proxy (>= 0.6.1)
+      railties (>= 5.2)
+      semantic_range (>= 2.3.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -285,6 +342,7 @@ GEM
     stringio (3.2.0)
     thor (1.5.0)
     timeout (0.6.0)
+    traces (0.18.2)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -321,12 +379,16 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  connection_pool (~> 2.5)
   debug
   importmap-rails
   puma (>= 5.0)
   rails (~> 7.2.3)
+  react_on_rails!
+  react_on_rails_pro!
   rubocop-rails-omakase
   selenium-webdriver
+  shakapacker (~> 9.3)
   sprockets-rails
   sqlite3 (>= 1.4)
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,11 @@
+# Procfile for development
+# You can run these commands in separate shells
+rails: bundle exec rails s -p 3000
+dev-server: bin/shakapacker-dev-server
+server-bundle: SERVER_BUNDLE_ONLY=yes bin/shakapacker --watch
+
+# React on Rails Pro - Node Renderer for SSR
+node-renderer: RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node client/node-renderer.js
+
+# React on Rails Pro - RSC bundle watcher
+rsc-bundle: RSC_BUNDLE_ONLY=yes bin/shakapacker --watch

--- a/Procfile.dev-prod-assets
+++ b/Procfile.dev-prod-assets
@@ -1,0 +1,8 @@
+# Procfile for development with production assets 
+# Uses production-optimized, precompiled assets with development environment
+# Uncomment additional processes as needed for your app
+
+rails: bundle exec rails s -p 3001
+# sidekiq: bundle exec sidekiq -C config/sidekiq.yml
+# redis: redis-server
+# mailcatcher: mailcatcher --foreground

--- a/Procfile.dev-static-assets
+++ b/Procfile.dev-static-assets
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+js: bin/shakapacker --watch

--- a/app/controllers/hello_server_controller.rb
+++ b/app/controllers/hello_server_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# HelloServer Controller - React Server Components
+# This controller demonstrates how to render RSC pages with streaming SSR.
+# It's the RSC counterpart to HelloWorldController.
+#
+# ReactOnRailsPro::Stream provides:
+# - stream_view_containing_react_components: Streams the view with RSC support
+# - Streaming HTML chunks as components render
+# - Automatic hydration on the client
+#
+# For more information, see:
+# https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/
+
+class HelloServerController < ApplicationController
+  include ReactOnRailsPro::Stream
+
+  def index
+    @hello_server_props = {
+      name: "React on Rails Pro"
+    }
+
+    stream_view_containing_react_components(template: "hello_server/index")
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class HomeController < ApplicationController
+  def index; end
+end

--- a/app/controllers/patterns_controller.rb
+++ b/app/controllers/patterns_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# PatternsController - RSC Migration Pattern Demos
+#
+# Each action demonstrates a different RSC migration pattern from
+# the React on Rails Pro migration guide (rsc-component-patterns.md).
+#
+# All actions use ReactOnRailsPro::Stream for streaming SSR with RSC support.
+
+class PatternsController < ApplicationController
+  include ReactOnRailsPro::Stream
+
+  # Pattern 1: Pushing State to Leaf Components
+  def product_page
+    @product_page_props = { productId: 1 }
+    stream_view_containing_react_components(template: "patterns/product_page")
+  end
+
+  # Pattern 2: The Donut Pattern (Children as Props)
+  def cart_page
+    @cart_page_props = {}
+    stream_view_containing_react_components(template: "patterns/cart_page")
+  end
+
+  # Pattern 3: Extracting State into a Wrapper Component
+  def theme_page
+    @theme_page_props = {}
+    stream_view_containing_react_components(template: "patterns/theme_page")
+  end
+
+  # Pattern 4: Async Server Components with Suspense
+  def dashboard
+    @dashboard_props = {}
+    stream_view_containing_react_components(template: "patterns/dashboard")
+  end
+
+  # Pattern 5: Server-to-Client Promise Handoff
+  def blog_post
+    @blog_post_props = { postId: 1 }
+    stream_view_containing_react_components(template: "patterns/blog_post")
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,0 +1,3 @@
+// Client entry point - required for Shakapacker to render pack tags in the layout.
+// Component-specific packs (generated/*) are appended automatically by
+// stream_react_component via auto_load_bundle.

--- a/app/javascript/packs/server-bundle.js
+++ b/app/javascript/packs/server-bundle.js
@@ -1,0 +1,3 @@
+// import statement added by react_on_rails:generate_packs rake task
+import "./../generated/server-bundle-generated.js"
+// Placeholder comment - auto-generated imports will be prepended here by react_on_rails:generate_packs

--- a/app/javascript/src/BlogPost/components/BlogPost.jsx
+++ b/app/javascript/src/BlogPost/components/BlogPost.jsx
@@ -1,0 +1,104 @@
+// Pattern 5: Server-to-Client Promise Handoff
+//
+// The post data is awaited on the server (critical, needed for SEO).
+// The comments promise is started on the server but NOT awaited —
+// it's passed to the Comments Client Component which resolves it
+// using React's `use()` hook. This avoids blocking the server render
+// while still starting the fetch early (close to the data source).
+
+import React, { Suspense } from 'react';
+import Comments from './Comments';
+
+async function getPost(id) {
+  // Critical data — await it (needed for the initial render)
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  return {
+    id,
+    title: 'Understanding React Server Components',
+    author: 'Jane Developer',
+    date: 'February 22, 2026',
+    body: `React Server Components represent a fundamental shift in how we build React applications.
+Unlike traditional SSR, where the server renders HTML but still ships all component JavaScript to
+the client for hydration, RSC keeps server components entirely on the server. The client never
+receives their code.
+
+This means heavy dependencies used in server components — markdown parsers, date formatting
+libraries, database clients — never end up in your client bundle. Only components marked with
+'use client' ship JavaScript to the browser.
+
+The migration guide covers five key patterns for restructuring your component tree to take
+advantage of this architecture. This blog post page itself demonstrates Pattern 5: the
+server-to-client promise handoff.`,
+  };
+}
+
+function getComments(postId) {
+  // Non-critical data — start the fetch but DON'T await
+  // This promise will be passed to the client component
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        { id: 1, author: 'Alex', text: 'Great explanation! The donut pattern was new to me.', time: '2 hours ago' },
+        { id: 2, author: 'Sam', text: 'We migrated our app using these patterns. Reduced client bundle by 40%.', time: '1 hour ago' },
+        { id: 3, author: 'Jordan', text: 'The promise handoff pattern is clever. Love that the fetch starts on the server.', time: '45 min ago' },
+        { id: 4, author: 'Taylor', text: 'Can you do a follow-up on Server Actions?', time: '20 min ago' },
+      ]);
+    }, 800); // Simulates slow comments API
+  });
+}
+
+const BlogPost = async ({ postId = 1 }) => {
+  // Await critical data (the post itself)
+  const post = await getPost(postId);
+
+  // Start but DON'T await non-critical data (comments)
+  const commentsPromise = getComments(postId);
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 700, margin: '0 auto' }}>
+      <div style={{
+        background: '#fff8e1',
+        border: '1px solid #ffcc80',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 16,
+        fontSize: '0.85em',
+      }}>
+        <strong>Pattern 5: Server-to-Client Promise Handoff</strong> — The blog post above
+        is awaited on the server and renders immediately. The comments below are fetched via
+        a promise that starts on the server but resolves on the client using React&apos;s{' '}
+        <code>use()</code> hook. This avoids blocking the server render.
+      </div>
+
+      <article>
+        <h1>{post.title}</h1>
+        <div style={{ color: '#666', marginBottom: 16, fontSize: '0.9em' }}>
+          By {post.author} | {post.date}
+        </div>
+        {post.body.split('\n\n').map((paragraph, i) => (
+          <p key={i} style={{ lineHeight: 1.7 }}>{paragraph}</p>
+        ))}
+      </article>
+
+      <hr style={{ margin: '32px 0' }} />
+
+      {/* Comments stream in when the promise resolves */}
+      <Suspense fallback={
+        <div style={{
+          padding: 24,
+          textAlign: 'center',
+          color: '#999',
+          background: '#fafafa',
+          borderRadius: 8,
+        }}>
+          Loading comments...
+        </div>
+      }>
+        <Comments commentsPromise={commentsPromise} />
+      </Suspense>
+    </div>
+  );
+};
+
+export default BlogPost;

--- a/app/javascript/src/BlogPost/components/Comments.jsx
+++ b/app/javascript/src/BlogPost/components/Comments.jsx
@@ -1,0 +1,68 @@
+'use client';
+
+// Comments - Client Component
+//
+// This component receives a promise that was started on the server
+// and resolves it using React's `use()` hook. The fetch begins early
+// (on the server, close to the data source) but doesn't block the
+// server render. The comments stream in when the promise resolves.
+
+import React, { use, useState } from 'react';
+
+const Comments = ({ commentsPromise }) => {
+  const comments = use(commentsPromise);
+  const [likes, setLikes] = useState({});
+
+  const toggleLike = (commentId) => {
+    setLikes((prev) => ({
+      ...prev,
+      [commentId]: !prev[commentId],
+    }));
+  };
+
+  return (
+    <div>
+      <h3>Comments ({comments.length})</h3>
+      {comments.map((comment) => (
+        <div key={comment.id} style={{
+          border: '1px solid #e0e0e0',
+          borderRadius: 8,
+          padding: 16,
+          marginBottom: 12,
+        }}>
+          <div style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 8,
+          }}>
+            <strong>{comment.author}</strong>
+            <span style={{ color: '#999', fontSize: '0.85em' }}>{comment.time}</span>
+          </div>
+          <p style={{ margin: '0 0 8px' }}>{comment.text}</p>
+          <button
+            type="button"
+            onClick={() => toggleLike(comment.id)}
+            style={{
+              padding: '4px 12px',
+              cursor: 'pointer',
+              borderRadius: 4,
+              border: '1px solid #ccc',
+              background: likes[comment.id] ? '#e3f2fd' : '#fff',
+              fontSize: '0.85em',
+            }}
+          >
+            {likes[comment.id] ? 'Liked' : 'Like'}
+          </button>
+        </div>
+      ))}
+      <p style={{ color: '#666', fontSize: '0.85em', marginTop: 16 }}>
+        These comments were fetched via a promise started on the server
+        and resolved on the client with <code>use()</code>.
+        The like buttons are interactive Client Component features.
+      </p>
+    </div>
+  );
+};
+
+export default Comments;

--- a/app/javascript/src/BlogPost/ror_components/BlogPost.jsx
+++ b/app/javascript/src/BlogPost/ror_components/BlogPost.jsx
@@ -1,0 +1,3 @@
+import BlogPost from '../components/BlogPost';
+
+export default BlogPost;

--- a/app/javascript/src/CartPage/components/CartPage.jsx
+++ b/app/javascript/src/CartPage/components/CartPage.jsx
@@ -1,0 +1,83 @@
+// Pattern 2: The Donut Pattern (Children as Props)
+//
+// The Modal is a Client Component that needs state (isOpen toggle).
+// The Cart content is a Server Component that fetches data on the server.
+// By using the `children` prop, Cart passes through the Modal without
+// becoming client code — the "donut hole" pattern.
+
+import React from 'react';
+import Modal from './Modal';
+
+async function getCartItems() {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  return [
+    { id: 1, name: 'Mechanical Keyboard', price: 149.99, qty: 1 },
+    { id: 2, name: 'USB-C Cable', price: 12.99, qty: 2 },
+    { id: 3, name: 'Monitor Stand', price: 34.99, qty: 1 },
+  ];
+}
+
+async function Cart() {
+  const items = await getCartItems();
+  const total = items.reduce((sum, item) => sum + item.price * item.qty, 0);
+
+  return (
+    <div>
+      <h3 style={{ margin: '0 0 16px' }}>Your Cart</h3>
+      {items.map((item) => (
+        <div key={item.id} style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: '8px 0',
+          borderBottom: '1px solid #eee',
+        }}>
+          <span>{item.name} x{item.qty}</span>
+          <span style={{ fontWeight: 'bold' }}>${(item.price * item.qty).toFixed(2)}</span>
+        </div>
+      ))}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '12px 0',
+        fontWeight: 'bold',
+        fontSize: '1.1em',
+      }}>
+        <span>Total:</span>
+        <span>${total.toFixed(2)}</span>
+      </div>
+      <p style={{ color: '#666', fontSize: '0.85em', margin: '8px 0 0' }}>
+        This cart content was rendered on the server — zero JS shipped for it.
+      </p>
+    </div>
+  );
+}
+
+const CartPage = async () => {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 600, margin: '0 auto' }}>
+      <div style={{
+        background: '#e3f2fd',
+        border: '1px solid #90caf9',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 16,
+        fontSize: '0.85em',
+      }}>
+        <strong>Pattern 2: The Donut Pattern</strong> — The Modal below is a Client Component
+        (it needs useState for open/close). But the Cart content inside it is a Server Component
+        passed via children — it never becomes client code!
+      </div>
+
+      <h1>Shopping</h1>
+      <p>Click the button below to see the donut pattern in action.</p>
+
+      {/* Modal is client (has state), Cart is server (passed as children) */}
+      <Modal>
+        <Cart />
+      </Modal>
+    </div>
+  );
+};
+
+export default CartPage;

--- a/app/javascript/src/CartPage/components/Modal.jsx
+++ b/app/javascript/src/CartPage/components/Modal.jsx
@@ -1,0 +1,86 @@
+'use client';
+
+// Modal - Client Component (the "donut")
+//
+// This component needs client-side state to toggle visibility.
+// Its content (children) can be Server Components — they pass through
+// without becoming client code. This is the "donut pattern":
+// the client component wraps around a server-rendered center.
+
+import React, { useState } from 'react';
+
+const Modal = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        style={{
+          padding: '12px 24px',
+          fontSize: '1em',
+          cursor: 'pointer',
+          borderRadius: 8,
+          border: '2px solid #1976d2',
+          background: '#1976d2',
+          color: '#fff',
+          fontWeight: 'bold',
+        }}
+      >
+        Open Cart
+      </button>
+
+      {isOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={() => setIsOpen(false)}
+        >
+          <div
+            style={{
+              background: '#fff',
+              borderRadius: 12,
+              padding: 24,
+              minWidth: 400,
+              maxWidth: 500,
+              boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Server-rendered content passes through here */}
+            {children}
+
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              style={{
+                marginTop: 16,
+                padding: '8px 16px',
+                cursor: 'pointer',
+                borderRadius: 6,
+                border: '1px solid #ccc',
+                background: '#f5f5f5',
+                width: '100%',
+              }}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Modal;

--- a/app/javascript/src/CartPage/ror_components/CartPage.jsx
+++ b/app/javascript/src/CartPage/ror_components/CartPage.jsx
@@ -1,0 +1,3 @@
+import CartPage from '../components/CartPage';
+
+export default CartPage;

--- a/app/javascript/src/Dashboard/components/Dashboard.jsx
+++ b/app/javascript/src/Dashboard/components/Dashboard.jsx
@@ -1,0 +1,233 @@
+// Pattern 4: Async Server Components with Suspense
+//
+// Each section (Stats, RevenueChart, RecentOrders) is an async Server Component
+// wrapped in its own <Suspense> boundary. They fetch data independently and
+// stream HTML to the browser as each completes — the user sees content
+// progressively rather than waiting for the slowest query.
+
+import React, { Suspense } from 'react';
+
+async function getStats() {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  return {
+    revenue: '$127,450',
+    users: '2,847',
+    orders: '1,234',
+    conversionRate: '3.2%',
+  };
+}
+
+async function getRevenueData() {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return {
+    months: ['Sep', 'Oct', 'Nov', 'Dec', 'Jan', 'Feb'],
+    values: [85000, 92000, 108000, 115000, 121000, 127450],
+  };
+}
+
+async function getRecentOrders() {
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  return [
+    { id: 'ORD-001', customer: 'Alice Johnson', amount: '$299.99', status: 'Shipped', date: '2026-02-21' },
+    { id: 'ORD-002', customer: 'Bob Smith', amount: '$149.50', status: 'Processing', date: '2026-02-21' },
+    { id: 'ORD-003', customer: 'Charlie Brown', amount: '$89.99', status: 'Delivered', date: '2026-02-20' },
+    { id: 'ORD-004', customer: 'Diana Prince', amount: '$449.00', status: 'Shipped', date: '2026-02-20' },
+    { id: 'ORD-005', customer: 'Eve Wilson', amount: '$67.25', status: 'Processing', date: '2026-02-19' },
+  ];
+}
+
+function StatsSkeleton() {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} style={{
+          background: '#f0f0f0',
+          borderRadius: 8,
+          padding: 20,
+          height: 80,
+          animation: 'pulse 1.5s ease-in-out infinite',
+        }} />
+      ))}
+    </div>
+  );
+}
+
+function ChartSkeleton() {
+  return (
+    <div style={{
+      background: '#f0f0f0',
+      borderRadius: 8,
+      padding: 20,
+      height: 200,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: '#999',
+    }}>
+      Loading chart...
+    </div>
+  );
+}
+
+function TableSkeleton() {
+  return (
+    <div style={{ borderRadius: 8, overflow: 'hidden' }}>
+      {[1, 2, 3, 4, 5].map((i) => (
+        <div key={i} style={{
+          background: '#f0f0f0',
+          height: 48,
+          marginBottom: 2,
+        }} />
+      ))}
+    </div>
+  );
+}
+
+async function Stats() {
+  const stats = await getStats();
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
+      {[
+        { label: 'Revenue', value: stats.revenue, color: '#2e7d32' },
+        { label: 'Users', value: stats.users, color: '#1565c0' },
+        { label: 'Orders', value: stats.orders, color: '#e65100' },
+        { label: 'Conv. Rate', value: stats.conversionRate, color: '#6a1b9a' },
+      ].map((stat) => (
+        <div key={stat.label} style={{
+          background: '#fff',
+          border: '1px solid #e0e0e0',
+          borderRadius: 8,
+          padding: 20,
+          textAlign: 'center',
+        }}>
+          <div style={{ fontSize: '0.85em', color: '#666', marginBottom: 4 }}>{stat.label}</div>
+          <div style={{ fontSize: '1.5em', fontWeight: 'bold', color: stat.color }}>{stat.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+async function RevenueChart() {
+  const data = await getRevenueData();
+  const max = Math.max(...data.values);
+
+  return (
+    <div style={{
+      background: '#fff',
+      border: '1px solid #e0e0e0',
+      borderRadius: 8,
+      padding: 20,
+    }}>
+      <h3 style={{ margin: '0 0 16px' }}>Revenue Trend</h3>
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12, height: 150 }}>
+        {data.months.map((month, i) => (
+          <div key={month} style={{ flex: 1, textAlign: 'center' }}>
+            <div style={{
+              background: '#42a5f5',
+              borderRadius: '4px 4px 0 0',
+              height: `${(data.values[i] / max) * 130}px`,
+              transition: 'height 0.3s',
+            }} />
+            <div style={{ fontSize: '0.8em', marginTop: 4, color: '#666' }}>{month}</div>
+            <div style={{ fontSize: '0.7em', color: '#999' }}>${(data.values[i] / 1000).toFixed(0)}k</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+async function RecentOrders() {
+  const orders = await getRecentOrders();
+
+  const statusColors = {
+    Shipped: '#1565c0',
+    Processing: '#e65100',
+    Delivered: '#2e7d32',
+  };
+
+  return (
+    <div style={{
+      background: '#fff',
+      border: '1px solid #e0e0e0',
+      borderRadius: 8,
+      overflow: 'hidden',
+    }}>
+      <h3 style={{ margin: 0, padding: '16px 20px', borderBottom: '1px solid #e0e0e0' }}>
+        Recent Orders
+      </h3>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr style={{ background: '#fafafa' }}>
+            <th style={{ padding: '10px 20px', textAlign: 'left' }}>Order</th>
+            <th style={{ padding: '10px 20px', textAlign: 'left' }}>Customer</th>
+            <th style={{ padding: '10px 20px', textAlign: 'right' }}>Amount</th>
+            <th style={{ padding: '10px 20px', textAlign: 'center' }}>Status</th>
+            <th style={{ padding: '10px 20px', textAlign: 'right' }}>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((order) => (
+            <tr key={order.id} style={{ borderTop: '1px solid #f0f0f0' }}>
+              <td style={{ padding: '10px 20px', fontFamily: 'monospace' }}>{order.id}</td>
+              <td style={{ padding: '10px 20px' }}>{order.customer}</td>
+              <td style={{ padding: '10px 20px', textAlign: 'right', fontWeight: 'bold' }}>{order.amount}</td>
+              <td style={{ padding: '10px 20px', textAlign: 'center' }}>
+                <span style={{
+                  padding: '2px 8px',
+                  borderRadius: 12,
+                  fontSize: '0.8em',
+                  color: '#fff',
+                  background: statusColors[order.status] || '#666',
+                }}>
+                  {order.status}
+                </span>
+              </td>
+              <td style={{ padding: '10px 20px', textAlign: 'right', color: '#666' }}>{order.date}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const Dashboard = () => {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 900, margin: '0 auto' }}>
+      <div style={{
+        background: '#f3e5f5',
+        border: '1px solid #ce93d8',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 16,
+        fontSize: '0.85em',
+      }}>
+        <strong>Pattern 4: Async Server Components with Suspense</strong> — Each section below
+        is an independent async Server Component wrapped in its own Suspense boundary.
+        They fetch data in parallel and stream to the browser as each completes.
+        Stats loads first (~200ms), Orders next (~350ms), Chart last (~500ms).
+      </div>
+
+      <h1>Dashboard</h1>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <Suspense fallback={<StatsSkeleton />}>
+          <Stats />
+        </Suspense>
+
+        <Suspense fallback={<ChartSkeleton />}>
+          <RevenueChart />
+        </Suspense>
+
+        <Suspense fallback={<TableSkeleton />}>
+          <RecentOrders />
+        </Suspense>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/app/javascript/src/Dashboard/ror_components/Dashboard.jsx
+++ b/app/javascript/src/Dashboard/ror_components/Dashboard.jsx
@@ -1,0 +1,3 @@
+import Dashboard from '../components/Dashboard';
+
+export default Dashboard;

--- a/app/javascript/src/HelloServer/components/HelloServer.jsx
+++ b/app/javascript/src/HelloServer/components/HelloServer.jsx
@@ -1,0 +1,80 @@
+// HelloServer - React Server Component
+//
+// This component runs ONLY on the server. No JavaScript for it is sent to the browser.
+// It demonstrates key RSC capabilities:
+//
+// 1. Async data fetching — use await directly in the component (no useEffect needed)
+// 2. Server-only code — access databases, file systems, or secrets safely
+// 3. Zero client JS — heavy libraries used here don't increase your bundle size
+// 4. Streaming — wrapped in <Suspense>, this component streams HTML as it resolves
+//
+// For more information, see:
+// https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/
+
+import React from 'react';
+import LikeButton from './LikeButton';
+
+// Simulate an async data fetch (replace with a real API call or DB query)
+async function fetchGreeting(name) {
+  // In a real app, you could do:
+  //   const data = await db.query('SELECT greeting FROM greetings WHERE name = ?', [name]);
+  //   const file = await fs.readFile('./data/greeting.txt', 'utf-8');
+  //   const res = await fetch('http://internal-api/greeting');
+  // eslint-disable-next-line no-promise-executor-return
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const now = new Date();
+  return {
+    message: `Hello, ${name}!`,
+    serverTime: now.toLocaleString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    }),
+    facts: [
+      'This component rendered entirely on the server — zero JS was sent to the browser for it.',
+      'The date formatting above used server-side Intl APIs — no date library shipped to the client.',
+      'The "Like" button below IS a client component — only its JS is sent to the browser.',
+    ],
+  };
+}
+
+const HelloServer = async ({ name = 'World' }) => {
+  const { message, serverTime, facts } = await fetchGreeting(name);
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 600, margin: '0 auto' }}>
+      <h2>{message}</h2>
+      <p style={{ color: '#666', fontSize: '0.9em' }}>Server-rendered at: {serverTime}</p>
+
+      <div
+        style={{
+          background: '#f0f9ff',
+          border: '1px solid #bae6fd',
+          borderRadius: 8,
+          padding: 16,
+          margin: '16px 0',
+        }}
+      >
+        <h3 style={{ margin: '0 0 12px' }}>How is this different from SSR?</h3>
+        <ul style={{ margin: 0, paddingLeft: 20 }}>
+          {facts.map((fact) => (
+            <li key={fact} style={{ marginBottom: 8 }}>
+              {fact}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* LikeButton is a client component — it ships JS for interactivity */}
+      <LikeButton />
+    </div>
+  );
+};
+
+export default HelloServer;

--- a/app/javascript/src/HelloServer/components/LikeButton.jsx
+++ b/app/javascript/src/HelloServer/components/LikeButton.jsx
@@ -1,0 +1,54 @@
+'use client';
+
+// LikeButton - Client Component
+//
+// This component has the 'use client' directive, so its JavaScript IS sent to the browser.
+// It demonstrates how client components work alongside server components:
+//
+// - Only this component's JS is included in the client bundle
+// - The parent HelloServer component sends ZERO JS to the browser
+// - React hydrates just this interactive island within the server-rendered HTML
+
+import React, { useState } from 'react';
+
+const LikeButton = () => {
+  const [likes, setLikes] = useState(0);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        marginTop: 16,
+        padding: '12px 16px',
+        background: '#fefce8',
+        border: '1px solid #fde68a',
+        borderRadius: 8,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setLikes((prev) => prev + 1)}
+        style={{
+          padding: '8px 16px',
+          fontSize: '1em',
+          cursor: 'pointer',
+          borderRadius: 6,
+          border: '1px solid #d1d5db',
+          background: '#fff',
+        }}
+      >
+        👍 Like
+      </button>
+      <span>
+        {likes} {likes === 1 ? 'like' : 'likes'}
+      </span>
+      <span style={{ color: '#92400e', fontSize: '0.85em' }}>
+        ← This button is a client component (check your browser&apos;s Network tab — only its JS was sent)
+      </span>
+    </div>
+  );
+};
+
+export default LikeButton;

--- a/app/javascript/src/HelloServer/ror_components/HelloServer.jsx
+++ b/app/javascript/src/HelloServer/ror_components/HelloServer.jsx
@@ -1,0 +1,10 @@
+// HelloServer Entry Point - Re-exports the server component for auto_load_bundle
+// This file is discovered by React on Rails' auto_load_bundle feature
+// and registered automatically in both client and server bundles.
+//
+// Note: No 'use client' directive here - this is a Server Component.
+// The actual component in ../components/HelloServer.jsx runs only on the server.
+
+import HelloServer from '../components/HelloServer';
+
+export default HelloServer;

--- a/app/javascript/src/ProductPage/components/AddToCartButton.jsx
+++ b/app/javascript/src/ProductPage/components/AddToCartButton.jsx
@@ -1,0 +1,75 @@
+'use client';
+
+// AddToCartButton - Client Component (interactive leaf)
+//
+// This is the ONLY component in Pattern 1 that ships JavaScript to the browser.
+// It demonstrates "pushing state to leaf components" - the parent ProductPage
+// fetches data on the server, and only this interactive piece runs on the client.
+
+import React, { useState } from 'react';
+
+const AddToCartButton = ({ productId, productName }) => {
+  const [quantity, setQuantity] = useState(1);
+  const [added, setAdded] = useState(false);
+
+  const handleAddToCart = () => {
+    setAdded(true);
+    setTimeout(() => setAdded(false), 2000);
+  };
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 12,
+      marginTop: 16,
+      padding: '16px',
+      background: '#fff3e0',
+      border: '1px solid #ffcc80',
+      borderRadius: 8,
+    }}>
+      <label style={{ fontWeight: 'bold' }}>
+        Qty:
+        <input
+          type="number"
+          min="1"
+          max="99"
+          value={quantity}
+          onChange={(e) => setQuantity(Math.max(1, Number(e.target.value)))}
+          style={{
+            width: 60,
+            marginLeft: 8,
+            padding: '6px 8px',
+            borderRadius: 4,
+            border: '1px solid #ccc',
+            fontSize: '1em',
+          }}
+        />
+      </label>
+
+      <button
+        type="button"
+        onClick={handleAddToCart}
+        disabled={added}
+        style={{
+          padding: '10px 24px',
+          fontSize: '1em',
+          cursor: added ? 'default' : 'pointer',
+          borderRadius: 6,
+          border: 'none',
+          background: added ? '#66bb6a' : '#ff9800',
+          color: '#fff',
+          fontWeight: 'bold',
+        }}
+      >
+        {added ? 'Added!' : `Add to Cart`}
+      </button>
+
+      <span style={{ color: '#e65100', fontSize: '0.85em' }}>
+        This button is a Client Component (only its JS is sent to the browser)
+      </span>
+    </div>
+  );
+};
+
+export default AddToCartButton;

--- a/app/javascript/src/ProductPage/components/ProductPage.jsx
+++ b/app/javascript/src/ProductPage/components/ProductPage.jsx
@@ -1,0 +1,111 @@
+// Pattern 1: Pushing State to Leaf Components
+//
+// This Server Component fetches product data directly on the server.
+// The interactive "Add to Cart" functionality is pushed down to a
+// dedicated Client Component leaf (AddToCartButton).
+//
+// Result: ProductSpecs, ReviewList, and all product data rendering
+// stay on the server. Only the add-to-cart interaction ships JS.
+
+import React from 'react';
+import AddToCartButton from './AddToCartButton';
+
+async function getProduct(productId) {
+  // Simulate server-side data fetch
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  const products = {
+    1: {
+      id: 1,
+      name: 'Mechanical Keyboard',
+      description: 'A premium mechanical keyboard with Cherry MX switches, RGB backlighting, and hot-swappable sockets.',
+      price: 149.99,
+      specs: [
+        { label: 'Switch Type', value: 'Cherry MX Brown' },
+        { label: 'Layout', value: '75% Compact' },
+        { label: 'Connectivity', value: 'USB-C / Bluetooth 5.0' },
+        { label: 'Battery', value: '4000mAh (wireless mode)' },
+      ],
+      reviews: [
+        { id: 1, author: 'Alice', rating: 5, text: 'Best keyboard I have ever used! The tactile feedback is amazing.' },
+        { id: 2, author: 'Bob', rating: 4, text: 'Great build quality. Wish it had more color options.' },
+        { id: 3, author: 'Charlie', rating: 5, text: 'Perfect for both coding and gaming.' },
+      ],
+    },
+  };
+
+  return products[productId] || products[1];
+}
+
+function ProductSpecs({ specs }) {
+  return (
+    <div style={{ background: '#f8f9fa', borderRadius: 8, padding: 16, margin: '16px 0' }}>
+      <h3 style={{ margin: '0 0 12px' }}>Specifications</h3>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <tbody>
+          {specs.map((spec) => (
+            <tr key={spec.label} style={{ borderBottom: '1px solid #e9ecef' }}>
+              <td style={{ padding: '8px 0', fontWeight: 'bold', width: '40%' }}>{spec.label}</td>
+              <td style={{ padding: '8px 0' }}>{spec.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ReviewList({ reviews }) {
+  const avgRating = (reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length).toFixed(1);
+
+  return (
+    <div style={{ margin: '16px 0' }}>
+      <h3>Reviews ({reviews.length}) - Average: {'*'.repeat(Math.round(avgRating))} {avgRating}/5</h3>
+      {reviews.map((review) => (
+        <div key={review.id} style={{
+          border: '1px solid #e9ecef',
+          borderRadius: 8,
+          padding: 12,
+          marginBottom: 8,
+        }}>
+          <strong>{review.author}</strong> - {'*'.repeat(review.rating)}
+          <p style={{ margin: '4px 0 0' }}>{review.text}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const ProductPage = async ({ productId = 1 }) => {
+  const product = await getProduct(productId);
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 700, margin: '0 auto' }}>
+      <div style={{
+        background: '#e8f5e9',
+        border: '1px solid #a5d6a7',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 16,
+        fontSize: '0.85em',
+      }}>
+        <strong>Pattern 1: Pushing State to Leaf Components</strong> - This entire page is a
+        Server Component. Only the &quot;Add to Cart&quot; button below ships JavaScript to the browser.
+        The product data, specs, and reviews are rendered entirely on the server.
+      </div>
+
+      <h1>{product.name}</h1>
+      <p style={{ fontSize: '1.5em', color: '#2e7d32', fontWeight: 'bold' }}>${product.price}</p>
+      <p>{product.description}</p>
+
+      {/* These stay on the server - zero JS shipped */}
+      <ProductSpecs specs={product.specs} />
+      <ReviewList reviews={product.reviews} />
+
+      {/* Only this ships JS to the client */}
+      <AddToCartButton productId={product.id} productName={product.name} />
+    </div>
+  );
+};
+
+export default ProductPage;

--- a/app/javascript/src/ProductPage/ror_components/ProductPage.jsx
+++ b/app/javascript/src/ProductPage/ror_components/ProductPage.jsx
@@ -1,0 +1,4 @@
+// ProductPage Entry Point - Re-exports the server component for auto_load_bundle
+import ProductPage from '../components/ProductPage';
+
+export default ProductPage;

--- a/app/javascript/src/ThemePage/components/ColorProvider.jsx
+++ b/app/javascript/src/ThemePage/components/ColorProvider.jsx
@@ -1,0 +1,77 @@
+'use client';
+
+// ColorProvider - Client Component (state wrapper)
+//
+// This component holds theme state and wraps its children with
+// the appropriate styles. The children (Header, MainContent, Footer)
+// are Server Components — they pass through without becoming client code.
+
+import React, { useState } from 'react';
+
+const THEMES = {
+  light: {
+    background: '#ffffff',
+    color: '#1a1a1a',
+    label: 'Light',
+  },
+  dark: {
+    background: '#1a1a2e',
+    color: '#e0e0e0',
+    label: 'Dark',
+  },
+  ocean: {
+    background: '#0d1b2a',
+    color: '#c9d6df',
+    label: 'Ocean',
+  },
+};
+
+const ColorProvider = ({ children }) => {
+  const [themeName, setThemeName] = useState('light');
+  const theme = THEMES[themeName];
+
+  return (
+    <div style={{
+      background: theme.background,
+      color: theme.color,
+      borderRadius: 12,
+      overflow: 'hidden',
+      transition: 'all 0.3s ease',
+      border: '1px solid #ccc',
+    }}>
+      <div style={{
+        padding: '8px 24px',
+        display: 'flex',
+        gap: 8,
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+        borderBottom: `1px solid ${theme.color}33`,
+      }}>
+        <span style={{ fontSize: '0.85em', marginRight: 8 }}>Theme:</span>
+        {Object.entries(THEMES).map(([key, t]) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setThemeName(key)}
+            style={{
+              padding: '4px 12px',
+              cursor: 'pointer',
+              borderRadius: 4,
+              border: key === themeName ? '2px solid #4fc3f7' : '1px solid #666',
+              background: key === themeName ? '#4fc3f733' : 'transparent',
+              color: theme.color,
+              fontSize: '0.85em',
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Server-rendered children pass through */}
+      {children}
+    </div>
+  );
+};
+
+export default ColorProvider;

--- a/app/javascript/src/ThemePage/components/ThemePage.jsx
+++ b/app/javascript/src/ThemePage/components/ThemePage.jsx
@@ -1,0 +1,110 @@
+// Pattern 3: Extracting State into a Wrapper Component
+//
+// The ColorProvider is a Client Component that holds theme state.
+// Header, MainContent, and Footer are Server Components passed as children.
+// Because ThemePage (a Server Component) is the "owner" that imports and
+// renders them, they stay on the server — even though they're visually
+// nested inside the Client Component ColorProvider.
+
+import React from 'react';
+import ColorProvider from './ColorProvider';
+
+async function getPageData() {
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  return {
+    headerTitle: 'RSC Migration Patterns',
+    navItems: ['Home', 'Patterns', 'Docs', 'About'],
+    content: {
+      title: 'Pattern 3: State Extraction',
+      body: 'This page demonstrates extracting state (theme toggle) into a wrapper component. The Header, MainContent, and Footer below are all Server Components — they ship zero JavaScript. Only the ColorProvider (which holds the theme state) and its toggle button are Client Components.',
+      features: [
+        'Theme state is isolated in ColorProvider (Client Component)',
+        'Header, MainContent, Footer remain Server Components',
+        'Children pass through the client boundary without becoming client code',
+        'Heavy rendering logic stays on the server',
+      ],
+    },
+    footerText: 'Built with React on Rails Pro RSC',
+    year: new Date().getFullYear(),
+  };
+}
+
+function Header({ title, navItems }) {
+  return (
+    <header style={{
+      padding: '16px 24px',
+      borderBottom: '1px solid currentColor',
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      opacity: 0.9,
+    }}>
+      <h2 style={{ margin: 0 }}>{title}</h2>
+      <nav style={{ display: 'flex', gap: 16 }}>
+        {navItems.map((item) => (
+          <span key={item} style={{ cursor: 'pointer' }}>{item}</span>
+        ))}
+      </nav>
+    </header>
+  );
+}
+
+function MainContent({ content }) {
+  return (
+    <main style={{ padding: 24, minHeight: 300 }}>
+      <h1>{content.title}</h1>
+      <p>{content.body}</p>
+      <ul>
+        {content.features.map((f) => (
+          <li key={f} style={{ marginBottom: 8 }}>{f}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+function Footer({ text, year }) {
+  return (
+    <footer style={{
+      padding: '16px 24px',
+      borderTop: '1px solid currentColor',
+      textAlign: 'center',
+      opacity: 0.7,
+      fontSize: '0.9em',
+    }}>
+      {text} - {year}
+    </footer>
+  );
+}
+
+const ThemePage = async () => {
+  const data = await getPageData();
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 800, margin: '0 auto' }}>
+      <div style={{
+        background: '#fce4ec',
+        border: '1px solid #f48fb1',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 16,
+        fontSize: '0.85em',
+        color: '#333',
+      }}>
+        <strong>Pattern 3: Extracting State into a Wrapper</strong> — The theme toggle
+        is a Client Component wrapper. Header, MainContent, and Footer are Server Components
+        passed as children — they stay on the server even though they appear inside the
+        client-side ColorProvider.
+      </div>
+
+      <ColorProvider>
+        <Header title={data.headerTitle} navItems={data.navItems} />
+        <MainContent content={data.content} />
+        <Footer text={data.footerText} year={data.year} />
+      </ColorProvider>
+    </div>
+  );
+};
+
+export default ThemePage;

--- a/app/javascript/src/ThemePage/ror_components/ThemePage.jsx
+++ b/app/javascript/src/ThemePage/ror_components/ThemePage.jsx
@@ -1,0 +1,3 @@
+import ThemePage from '../components/ThemePage';
+
+export default ThemePage;

--- a/app/views/hello_server/index.html.erb
+++ b/app/views/hello_server/index.html.erb
@@ -1,0 +1,37 @@
+<h1>React Server Components Demo</h1>
+
+<p>
+  This page demonstrates <strong>React Server Components (RSC)</strong> with React on Rails Pro.
+  The component below is an <em>async server component</em> that fetches data on the server
+  and streams HTML to the browser. No component JavaScript is sent to the client.
+</p>
+
+<%#
+  stream_react_component renders the RSC with streaming support.
+
+  Key points:
+  - prerender: true enables server-side rendering with streaming
+  - Props are passed from the controller (@hello_server_props)
+  - The component streams as it resolves (async data fetching happens server-side)
+  - Only the interactive LikeButton client component ships JS to the browser
+  - Open DevTools Network tab to verify — no HelloServer.js in the client bundle
+%>
+<%= stream_react_component('HelloServer', props: @hello_server_props, prerender: true) %>
+
+<hr>
+
+<details style="margin-top: 16px;">
+  <summary><strong>What makes this different from traditional SSR?</strong></summary>
+  <ul style="margin-top: 8px;">
+    <li><strong>Traditional SSR:</strong> Server renders HTML, then ships ALL component JS to the browser for hydration. Every library used in rendering is in your bundle.</li>
+    <li><strong>RSC:</strong> Server components stay on the server permanently. Only client components (marked with <code>'use client'</code>) ship JS. Libraries used in server components are never bundled for the client.</li>
+    <li><strong>Async by default:</strong> Server components can be async functions that <code>await</code> data directly — no <code>useEffect</code>, no loading states for initial render, no client-side fetch waterfalls.</li>
+  </ul>
+</details>
+
+<p style="margin-top: 16px;">
+  <strong>Learn more:</strong>
+  <a href="https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/">
+    React Server Components Documentation
+  </a>
+</p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,81 @@
+<div style="font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 32px 16px;">
+  <h1>RSC Migration Patterns</h1>
+  <p style="color: #555; font-size: 1.1em; margin-bottom: 32px;">
+    Interactive demos of the 5 component tree restructuring patterns from the
+    <strong>React on Rails Pro</strong> RSC migration guide. Each pattern shows a different
+    technique for splitting components into Server and Client parts.
+  </p>
+
+  <div style="display: grid; gap: 16px;">
+    <a href="/patterns/product_page" style="text-decoration: none; color: inherit;">
+      <div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 20px; transition: box-shadow 0.2s; background: #fff;">
+        <h2 style="margin: 0 0 8px; color: #2e7d32;">Pattern 1: Pushing State to Leaf Components</h2>
+        <p style="margin: 0; color: #555;">
+          The most common pattern. A Server Component fetches product data, while only the
+          interactive "Add to Cart" button is a Client Component. Everything else stays on the server.
+        </p>
+        <span style="display: inline-block; margin-top: 8px; font-size: 0.85em; color: #999;">
+          Server: ProductPage, ProductSpecs, ReviewList &middot; Client: AddToCartButton
+        </span>
+      </div>
+    </a>
+
+    <a href="/patterns/cart_page" style="text-decoration: none; color: inherit;">
+      <div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 20px; transition: box-shadow 0.2s; background: #fff;">
+        <h2 style="margin: 0 0 8px; color: #1565c0;">Pattern 2: The Donut Pattern (Children as Props)</h2>
+        <p style="margin: 0; color: #555;">
+          A Client Component (Modal) wraps Server Component content (Cart) via <code>children</code>.
+          The server-rendered cart passes through the modal without becoming client code.
+        </p>
+        <span style="display: inline-block; margin-top: 8px; font-size: 0.85em; color: #999;">
+          Server: CartPage, Cart &middot; Client: Modal
+        </span>
+      </div>
+    </a>
+
+    <a href="/patterns/theme_page" style="text-decoration: none; color: inherit;">
+      <div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 20px; transition: box-shadow 0.2s; background: #fff;">
+        <h2 style="margin: 0 0 8px; color: #6a1b9a;">Pattern 3: Extracting State into a Wrapper</h2>
+        <p style="margin: 0; color: #555;">
+          Theme state is isolated in a Client Component wrapper (ColorProvider), while Header,
+          MainContent, and Footer remain Server Components passed as children.
+        </p>
+        <span style="display: inline-block; margin-top: 8px; font-size: 0.85em; color: #999;">
+          Server: ThemePage, Header, MainContent, Footer &middot; Client: ColorProvider
+        </span>
+      </div>
+    </a>
+
+    <a href="/patterns/dashboard" style="text-decoration: none; color: inherit;">
+      <div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 20px; transition: box-shadow 0.2s; background: #fff;">
+        <h2 style="margin: 0 0 8px; color: #e65100;">Pattern 4: Async Server Components with Suspense</h2>
+        <p style="margin: 0; color: #555;">
+          Three async Server Components (Stats, RevenueChart, RecentOrders) each wrapped in
+          <code>&lt;Suspense&gt;</code> boundaries for independent streaming. No client JS at all.
+        </p>
+        <span style="display: inline-block; margin-top: 8px; font-size: 0.85em; color: #999;">
+          Server: Dashboard, Stats, RevenueChart, RecentOrders &middot; Client: none
+        </span>
+      </div>
+    </a>
+
+    <a href="/patterns/blog_post" style="text-decoration: none; color: inherit;">
+      <div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 20px; transition: box-shadow 0.2s; background: #fff;">
+        <h2 style="margin: 0 0 8px; color: #c62828;">Pattern 5: Server-to-Client Promise Handoff</h2>
+        <p style="margin: 0; color: #555;">
+          The server awaits critical data (blog post) but passes a pending promise (comments) to a
+          Client Component that resolves it with <code>use()</code>. The post renders immediately.
+        </p>
+        <span style="display: inline-block; margin-top: 8px; font-size: 0.85em; color: #999;">
+          Server: BlogPost &middot; Client: Comments
+        </span>
+      </div>
+    </a>
+  </div>
+
+  <hr style="margin: 32px 0; border: none; border-top: 1px solid #e0e0e0;">
+
+  <a href="/hello_server" style="color: #1976d2;">
+    Hello Server (generator default demo)
+  </a>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application" %>
-    <%= javascript_importmap_tags %>
+    <%= javascript_pack_tag 'application', async: true %>
   </head>
 
   <body>

--- a/app/views/patterns/blog_post.html.erb
+++ b/app/views/patterns/blog_post.html.erb
@@ -1,0 +1,7 @@
+<h1>Pattern 5: Server-to-Client Promise Handoff</h1>
+<p>
+  The blog post is <strong>awaited on the server</strong> (renders immediately).
+  The comments promise is started on the server but resolved on the client via <code>use()</code>.
+</p>
+
+<%= stream_react_component('BlogPost', props: @blog_post_props, prerender: true) %>

--- a/app/views/patterns/cart_page.html.erb
+++ b/app/views/patterns/cart_page.html.erb
@@ -1,0 +1,7 @@
+<h1>Pattern 2: The Donut Pattern (Children as Props)</h1>
+<p>
+  The Modal is a <strong>Client Component</strong> (needs state for open/close).
+  The Cart content inside it is a <strong>Server Component</strong> passed via <code>children</code>.
+</p>
+
+<%= stream_react_component('CartPage', props: @cart_page_props, prerender: true) %>

--- a/app/views/patterns/dashboard.html.erb
+++ b/app/views/patterns/dashboard.html.erb
@@ -1,0 +1,7 @@
+<h1>Pattern 4: Async Server Components with Suspense</h1>
+<p>
+  Each dashboard section is an independent <strong>async Server Component</strong> wrapped in
+  <code>&lt;Suspense&gt;</code>. They stream progressively as their data fetches complete.
+</p>
+
+<%= stream_react_component('Dashboard', props: @dashboard_props, prerender: true) %>

--- a/app/views/patterns/product_page.html.erb
+++ b/app/views/patterns/product_page.html.erb
@@ -1,0 +1,7 @@
+<h1>Pattern 1: Pushing State to Leaf Components</h1>
+<p>
+  The ProductPage is a <strong>Server Component</strong> that fetches product data on the server.
+  Only the AddToCartButton is a Client Component — it's the only part that ships JavaScript.
+</p>
+
+<%= stream_react_component('ProductPage', props: @product_page_props, prerender: true) %>

--- a/app/views/patterns/theme_page.html.erb
+++ b/app/views/patterns/theme_page.html.erb
@@ -1,0 +1,7 @@
+<h1>Pattern 3: Extracting State into a Wrapper</h1>
+<p>
+  The ColorProvider holds theme state (Client Component).
+  Header, MainContent, and Footer are <strong>Server Components</strong> passed as children.
+</p>
+
+<%= stream_react_component('ThemePage', props: @theme_page_props, prerender: true) %>

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,36 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/babel.config.js
+
+module.exports = function (api) {
+  const defaultConfigFunc = require('shakapacker/package/babel/preset.js')
+  const resultConfig = defaultConfigFunc(api)
+  const isProductionEnv = api.env('production')
+
+  const changesOnDefault = {
+    presets: [
+      [
+        '@babel/preset-react',
+        {
+          development: !isProductionEnv,
+          useBuiltIns: true,
+          runtime: 'automatic'
+        }
+      ]
+    ].filter(Boolean),
+    plugins: [
+      // Enable React Refresh (Fast Refresh) only when webpack-dev-server is running (HMR mode)
+      // This prevents React Refresh from trying to connect when using static compilation
+      !isProductionEnv && process.env.WEBPACK_SERVE && 'react-refresh/babel',
+      isProductionEnv && ['babel-plugin-transform-react-remove-prop-types',
+        {
+          removeImport: true
+        }
+      ]
+    ].filter(Boolean),
+  }
+
+  resultConfig.presets = [...resultConfig.presets, ...changesOnDefault.presets]
+  resultConfig.plugins = [...resultConfig.plugins, ...changesOnDefault.plugins ]
+
+  return resultConfig
+}

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# ReactOnRails Development Server
+#
+# This script provides a simple interface to the ReactOnRails development
+# server management. The core logic is implemented in ReactOnRails::Dev
+# classes for better maintainability and testing.
+#
+# Each command uses a specific Procfile for process management:
+# - bin/dev (default/hmr): Uses Procfile.dev
+# - bin/dev static: Uses Procfile.dev-static-assets
+# - bin/dev prod: Uses Procfile.dev-prod-assets
+#
+# To customize development environment:
+# 1. Edit the appropriate Procfile to modify which processes run
+# 2. Modify this script for project-specific command-line behavior
+# 3. Extend ReactOnRails::Dev classes in your Rails app for advanced customization
+# 4. Use classes directly: ReactOnRails::Dev::ServerManager.start(:development, "Custom.procfile")
+#
+# EXTENSIBLE PRECOMPILE PATTERN (Alternative to precompile_hook)
+# ===============================================================
+# If your project has custom build requirements (e.g., ReScript, TypeScript
+# compilation, custom locale generation), you can handle precompile tasks
+# directly in this script instead of using the precompile_hook mechanism.
+#
+# Benefits of this approach:
+# - Single place to manage all precompile tasks
+# - Direct Ruby API calls (faster, no shell spawning overhead)
+# - Better version manager compatibility (mise, asdf, rbenv)
+# - Clean Procfiles without embedded precompile logic
+#
+# To use this pattern:
+# 1. Uncomment and customize the run_precompile_tasks method below
+# 2. Remove precompile_hook from config/shakapacker.yml if present
+# 3. Uncomment the run_precompile_tasks call near the bottom of this file
+#
+# See documentation: https://www.shakacode.com/react-on-rails/docs/building-features/extensible-precompile-pattern
+#
+# def run_precompile_tasks
+#   require_relative "../config/environment"
+#
+#   puts "📦 Running precompile tasks..."
+#
+#   # Example: Build ReScript files
+#   # print "   ReScript build... "
+#   # unless system("yarn res:build")
+#   #   puts "❌"
+#   #   exit(1)
+#   # end
+#   # puts "✅"
+#
+#   # Example: Generate locales using direct Ruby API (faster than rake task)
+#   # This avoids shell spawning and version manager PATH issues.
+#   # Exceptions (e.g., missing directories) will bubble up and stop the server,
+#   # which is the desired behavior for catching configuration issues early.
+#   print "   Locale generation... "
+#   ReactOnRails::Locales.compile if ReactOnRails.configuration.i18n_dir.present?
+#   puts "✅"
+#
+#   puts ""
+# end
+
+require "bundler/setup"
+require "react_on_rails/dev"
+
+# Default route configuration
+# This is set by the ReactOnRails installer to point to your generated component.
+# Change this to your preferred default route, or pass --route=<route> to override.
+DEFAULT_ROUTE = "hello_server"
+
+# Main execution
+# Add the default route to ARGV if no --route option is provided
+argv_with_defaults = ARGV.dup
+argv_with_defaults.push("--route=#{DEFAULT_ROUTE}") unless argv_with_defaults.any? { |arg| arg.start_with?("--route") }
+
+# Uncomment to run custom precompile tasks before starting the server
+# Only run for server start commands (not kill/help)
+# unless ARGV.include?("kill") || ARGV.include?("-h") || ARGV.include?("--help") || ARGV.include?("help")
+#   run_precompile_tasks
+# end
+
+ReactOnRails::Dev::ServerManager.run_from_command_line(argv_with_defaults)

--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,9 @@ FileUtils.chdir APP_ROOT do
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
+  # Install JavaScript dependencies
+  system!("npm install")
+
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"

--- a/bin/shakapacker
+++ b/bin/shakapacker
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+ENV["RAILS_ENV"] ||= "development"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["APP_ROOT"] ||= File.expand_path("..", __dir__)
+
+require "bundler/setup"
+require "shakapacker"
+require "shakapacker/runner"
+
+Shakapacker::Runner.run(ARGV)

--- a/bin/shakapacker-config
+++ b/bin/shakapacker-config
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+// Minimal shim - all logic is in the TypeScript module
+const { run } = require("shakapacker/configExporter")
+
+run(process.argv.slice(2))
+  .then((exitCode) => process.exit(exitCode))
+  .catch((error) => {
+    console.error(error.message)
+    process.exit(1)
+  })

--- a/bin/shakapacker-dev-server
+++ b/bin/shakapacker-dev-server
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+ENV["RAILS_ENV"] ||= "development"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+require "bundler/setup"
+require "shakapacker"
+require "shakapacker/dev_server_runner"
+
+APP_ROOT = File.expand_path("..", __dir__)
+Dir.chdir(APP_ROOT) do
+  Shakapacker::DevServerRunner.run(ARGV)
+end

--- a/bin/shakapacker-precompile-hook
+++ b/bin/shakapacker-precompile-hook
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Self-guard: skip if bin/dev already ran precompile tasks.
+# This prevents duplicate execution in HMR mode (two webpack processes)
+# regardless of Shakapacker version.
+exit 0 if ENV["SHAKAPACKER_SKIP_PRECOMPILE_HOOK"] == "true"
+
+# Shakapacker precompile hook for React on Rails
+#
+# This script runs before webpack compilation to generate pack files
+# for auto-bundled components. It's called automatically by Shakapacker
+# when configured in config/shakapacker.yml:
+#   precompile_hook: 'bin/shakapacker-precompile-hook'
+#
+# Emoji Scheme:
+#   🔄 = Running/in-progress
+#   ✅ = Success
+#   ❌ = Error
+
+# Skip validation during precompile hook execution
+# The hook runs early in the build process, potentially before full Rails initialization,
+# and doesn't need package version validation since it's part of the build itself
+ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
+
+require_relative "../config/environment"
+
+begin
+  puts Rainbow("🔄 Running React on Rails precompile hook...").cyan
+  ReactOnRails::PacksGenerator.instance.generate_packs_if_stale
+rescue StandardError => e
+  warn Rainbow("❌ Error in precompile hook: #{e.message}").red
+  warn e.backtrace.first(5).join("\n")
+  exit 1
+end

--- a/bin/switch-bundler
+++ b/bin/switch-bundler
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+
+# Script to switch between webpack and rspack bundlers
+class BundlerSwitcher
+  WEBPACK_DEPS = {
+    dependencies: %w[webpack webpack-assets-manifest webpack-merge],
+    dev_dependencies: %w[webpack-cli webpack-dev-server @pmmmwh/react-refresh-webpack-plugin]
+  }.freeze
+
+  RSPACK_DEPS = {
+    dependencies: %w[@rspack/core rspack-manifest-plugin],
+    dev_dependencies: %w[@rspack/cli @rspack/plugin-react-refresh]
+  }.freeze
+
+  def initialize(target_bundler)
+    @target_bundler = target_bundler.to_s.downcase
+    @shakapacker_config = "config/shakapacker.yml"
+    validate_bundler!
+  end
+
+  def switch!
+    puts "🔄 Switching to #{@target_bundler}..."
+
+    update_shakapacker_config
+    update_dependencies
+    install_dependencies
+
+    puts "✅ Successfully switched to #{@target_bundler}!"
+    puts "\nNext steps:"
+    puts "  1. Review your webpack configuration files in config/webpack/"
+    puts "  2. Restart your development server"
+  end
+
+  private
+
+  def validate_bundler!
+    return if %w[webpack rspack].include?(@target_bundler)
+
+    abort "❌ Invalid bundler: #{@target_bundler}. Use 'webpack' or 'rspack'"
+  end
+
+  def update_shakapacker_config
+    abort "❌ #{@shakapacker_config} not found" unless File.exist?(@shakapacker_config)
+
+    puts "📝 Updating #{@shakapacker_config}..."
+    content = File.read(@shakapacker_config)
+
+    # Use regex replacement to preserve file structure (comments, anchors, aliases)
+    # This replaces ALL occurrences of assets_bundler, not just in default section
+    old_bundler = @target_bundler == "rspack" ? "webpack" : "rspack"
+    new_content = content.gsub(
+      /^(\s*assets_bundler:\s*)["']?#{old_bundler}["']?(\s*(?:#.*)?)$/,
+      "\\1#{@target_bundler}\\2"
+    )
+
+    # Update javascript_transpiler based on bundler (rspack works best with SWC)
+    new_loader = @target_bundler == "rspack" ? "swc" : "babel"
+    old_loader = @target_bundler == "rspack" ? "babel" : "swc"
+    new_content = new_content.gsub(
+      /^(\s*javascript_transpiler:\s*)["']?#{old_loader}["']?(\s*(?:#.*)?)$/,
+      "\\1#{new_loader}\\2"
+    )
+
+    File.write(@shakapacker_config, new_content)
+    puts "✅ Updated assets_bundler to '#{@target_bundler}'"
+  end
+
+  def update_dependencies
+    puts "📦 Updating package.json dependencies..."
+
+    package_json_path = "package.json"
+    unless File.exist?(package_json_path)
+      puts "⚠️  package.json not found, skipping dependency updates"
+      return
+    end
+
+    package_json = JSON.parse(File.read(package_json_path))
+
+    remove_deps = @target_bundler == "rspack" ? WEBPACK_DEPS : RSPACK_DEPS
+
+    # Remove old bundler dependencies
+    remove_deps[:dependencies].each do |dep|
+      package_json["dependencies"]&.delete(dep)
+    end
+    remove_deps[:dev_dependencies].each do |dep|
+      package_json["devDependencies"]&.delete(dep)
+    end
+
+    puts "✅ Removed #{@target_bundler == 'rspack' ? 'webpack' : 'rspack'} dependencies"
+    File.write(package_json_path, JSON.pretty_generate(package_json))
+  end
+
+  def install_dependencies
+    puts "📥 Installing #{@target_bundler} dependencies..."
+
+    deps = @target_bundler == "rspack" ? RSPACK_DEPS : WEBPACK_DEPS
+
+    # Detect package manager
+    package_manager = detect_package_manager
+
+    # Install dependencies using array form to prevent command injection
+    success = case package_manager
+              when "yarn"
+                system("yarn", "add", *deps[:dependencies])
+              when "pnpm"
+                system("pnpm", "add", *deps[:dependencies])
+              else
+                system("npm", "install", *deps[:dependencies])
+              end
+
+    abort("❌ Failed to install dependencies") unless success
+
+    # Install dev dependencies using array form to prevent command injection
+    success = case package_manager
+              when "yarn"
+                system("yarn", "add", "-D", *deps[:dev_dependencies])
+              when "pnpm"
+                system("pnpm", "add", "-D", *deps[:dev_dependencies])
+              else
+                system("npm", "install", "--save-dev", *deps[:dev_dependencies])
+              end
+
+    abort("❌ Failed to install dev dependencies") unless success
+
+    puts "✅ Installed #{@target_bundler} dependencies"
+  end
+
+  def detect_package_manager
+    return "yarn" if File.exist?("yarn.lock")
+    return "pnpm" if File.exist?("pnpm-lock.yaml")
+
+    "npm"
+  end
+end
+
+# Main execution
+if ARGV.empty?
+  puts "Usage: bin/switch-bundler [webpack|rspack]"
+  puts "\nExamples:"
+  puts "  bin/switch-bundler rspack   # Switch to Rspack"
+  puts "  bin/switch-bundler webpack  # Switch to Webpack"
+  puts "\nNote: This also updates javascript_transpiler (rspack uses swc, webpack uses babel)"
+  exit 1
+end
+
+BundlerSwitcher.new(ARGV[0]).switch!

--- a/client/node-renderer.js
+++ b/client/node-renderer.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const { reactOnRailsProNodeRenderer } = require('react-on-rails-pro-node-renderer');
+
+const { env } = process;
+
+const config = {
+  serverBundleCachePath: path.resolve(__dirname, '../.node-renderer-bundles'),
+  port: Number(env.RENDERER_PORT) || 3800,
+  logLevel: env.RENDERER_LOG_LEVEL || 'info',
+
+  // See value in /config/initializers/react_on_rails_pro.rb
+  password: env.RENDERER_PASSWORD || 'devPassword',
+
+  // Number of Node.js worker threads for SSR rendering
+  // Set NODE_RENDERER_CONCURRENCY env var to override (e.g., for production tuning)
+  workersCount: env.NODE_RENDERER_CONCURRENCY != null ? Number(env.NODE_RENDERER_CONCURRENCY) : 3,
+
+  // If set to true, `supportModules` enables the server-bundle code to call a default set of NodeJS modules
+  // that get added to the VM context: { Buffer, process, setTimeout, setInterval, clearTimeout, clearInterval }.
+  // This option is required to equal `true` if you want to use loadable components.
+  // Setting this value to false causes the NodeRenderer to behave like ExecJS
+  supportModules: true,
+
+  // Additional Node.js globals to add to the VM context.
+  additionalContext: { URL, AbortController },
+
+  // Required to use setTimeout, setInterval, & clearTimeout during server rendering
+  stubTimers: false,
+
+  // Replay console logs from async server operations
+  replayServerAsyncOperationLogs: true,
+};
+
+// Renderer detects a total number of CPUs on virtual hostings like Heroku or CircleCI instead
+// of CPUs number allocated for current container. This results in spawning many workers while
+// only 1-2 of them really needed.
+if (env.CI) {
+  config.workersCount = 2;
+}
+
+reactOnRailsProNodeRenderer(config);

--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# React on Rails configuration
+# See https://github.com/shakacode/react_on_rails/blob/master/docs/configuration/README.md
+# for complete documentation of all configuration options.
+
+ReactOnRails.configure do |config|
+  ################################################################################
+  # Server Rendering (Recommended)
+  ################################################################################
+  # Configure server bundle for server-side rendering with `prerender: true`
+  # Set to "" if you're not using server rendering
+  config.server_bundle_js_file = "server-bundle.js"
+
+  # ⚠️ RECOMMENDED: Use Shakapacker 9.0+ private_output_path instead
+  #
+  # If using Shakapacker 9.0+, add to config/shakapacker.yml:
+  #   private_output_path: ssr-generated
+  #
+  # React on Rails will auto-detect this value, eliminating the need to set it here.
+  # This keeps your webpack and Rails configs in sync automatically.
+  #
+  # For older Shakapacker versions or custom setups, manually configure:
+  # config.server_bundle_output_path = "ssr-generated"
+  #
+  # The path is relative to Rails.root and should point to a private directory
+  # (outside of public/) for security. Run 'rails react_on_rails:doctor' to verify.
+
+  # Enforce that server bundles are only loaded from private (non-public) directories.
+  # When true, server bundles will only be loaded from the configured server_bundle_output_path.
+  # This is recommended for production to prevent server-side code from being exposed.
+  config.enforce_private_server_bundles = true
+
+  ################################################################################
+  # Test Configuration (Optional)
+  ################################################################################
+  # ⚠️ IMPORTANT: Two mutually exclusive approaches - use ONLY ONE:
+  #
+  # RECOMMENDED APPROACH: Set `compile: true` in config/shakapacker.yml test section
+  # - Simpler configuration (no additional setup needed)
+  # - Handled automatically by Shakapacker
+  #
+  # ALTERNATIVE APPROACH: Uncomment below AND configure ReactOnRails::TestHelper
+  # - Provides explicit control over test asset compilation timing
+  # - Requires adding ReactOnRails::TestHelper to spec/rails_helper.rb
+  # - See: https://github.com/shakacode/react_on_rails/blob/master/docs/building-features/testing-configuration.md
+  #
+  config.build_test_command = "RAILS_ENV=test bin/shakapacker"
+
+  config.auto_load_bundle = true
+  config.components_subdirectory = "ror_components"
+  ################################################################################
+  # Advanced Configuration
+  ################################################################################
+  # Most configuration options have sensible defaults and don't need to be set.
+  # For advanced options including:
+  # - File-based component registry (components_subdirectory, auto_load_bundle)
+  # - Component loading strategies (async/defer/sync)
+  # - Server bundle security and organization
+  # - I18n configuration
+  # - Server rendering pool configuration
+  # - Custom rendering extensions
+  # - And more...
+  #
+  # See: https://github.com/shakacode/react_on_rails/blob/master/docs/configuration/README.md
+end

--- a/config/initializers/react_on_rails_pro.rb
+++ b/config/initializers/react_on_rails_pro.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# See https://www.shakacode.com/react-on-rails-pro/docs/configuration/
+# License: Set REACT_ON_RAILS_PRO_LICENSE environment variable
+ReactOnRailsPro.configure do |config|
+  config.server_renderer = "NodeRenderer"
+  config.renderer_url = ENV.fetch("REACT_RENDERER_URL", "http://localhost:3800")
+
+  # See value in client/node-renderer.js
+  config.renderer_password = ENV.fetch("RENDERER_PASSWORD", "devPassword")
+
+  config.ssr_timeout = 5
+  config.renderer_request_retry_limit = 1
+  config.renderer_use_fallback_exec_js = Rails.env.development?
+
+  # If you want Honeybadger or Sentry on the Node renderer side to report rendering errors
+  config.throw_js_errors = false
+
+  # If true, then cache the evaluation of JS for prerendering using the standard Rails cache.
+  # Applies to all rendering engines.
+  config.prerender_caching = true
+
+  # Get timing of server render calls
+  config.tracing = Rails.env.development?
+
+  # React Server Components configuration
+  config.enable_rsc_support = true
+  config.rsc_bundle_js_file = "rsc-bundle.js"
+  config.rsc_payload_generation_url_path = "rsc_payload/"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "home#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,13 @@
 Rails.application.routes.draw do
+  get 'hello_server', to: 'hello_server#index'
+  rsc_payload_route
+
+  # RSC Migration Patterns
+  get 'patterns/product_page', to: 'patterns#product_page'  # Pattern 1
+  get 'patterns/cart_page', to: 'patterns#cart_page'         # Pattern 2
+  get 'patterns/theme_page', to: 'patterns#theme_page'       # Pattern 3
+  get 'patterns/dashboard', to: 'patterns#dashboard'         # Pattern 4
+  get 'patterns/blog_post', to: 'patterns#blog_post'         # Pattern 5
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -1,0 +1,191 @@
+# Note: You must restart bin/shakapacker-dev-server for changes to take effect
+# This file contains the defaults used by shakapacker.
+
+default: &default
+  source_path: app/javascript
+
+  # You can have a subdirectory of the source_path, like 'packs' (recommended).
+  # Alternatively, you can use '/' to use the whole source_path directory.
+  # Notice that this is a relative path to source_path
+  source_entry_path: packs
+
+  # If nested_entries is true, then we'll pick up subdirectories within the source_entry_path.
+  # You cannot set this option to true if you set source_entry_path to '/'
+  nested_entries: true
+
+  #  While using a File-System-based automated bundle generation feature, miscellaneous warnings suggesting css order
+  #  conflicts may arise due to the mini-css-extract-plugin. For projects where css ordering has been mitigated through
+  #  consistent use of scoping or naming conventions, the css order warnings can be disabled by setting
+  #  css_extract_ignore_order_warnings to true
+  css_extract_ignore_order_warnings: false
+
+  # CSS Modules export mode
+  # Controls how CSS Module class names are exported in JavaScript
+  # Defaults to 'named' if not specified. Uncomment and change to 'default' for v8 behavior.
+  # Options:
+  #   - named (default): Use named exports with camelCase conversion (v9 default)
+  #     Example: import { button } from './styles.module.css'
+  #   - default: Use default export with both original and camelCase names (v8 behavior)
+  #     Example: import styles from './styles.module.css'
+  # For gradual migration, you can set this to default to maintain v8 behavior
+  # See https://github.com/shakacode/shakapacker/blob/main/docs/css-modules-export-mode.md
+  # css_modules_export_mode: named
+
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/shakapacker
+  webpack_compile_output: true
+  # See https://github.com/shakacode/shakapacker#deployment
+  shakapacker_precompile: true
+
+  # Location for manifest.json, defaults to {public_output_path}/manifest.json if unset
+  # manifest_path: public/packs/manifest.json
+
+  # Location for private server-side bundles (e.g., for SSR)
+  # These bundles are not served publicly, unlike public_output_path
+  private_output_path: ssr-generated
+
+  # Additional paths webpack should look up modules
+  # ['app/assets', 'engine/foo/app/assets']
+  additional_paths: []
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+  # Select JavaScript transpiler to use
+  # Available options: 'swc' (default, 20x faster), 'babel', 'esbuild', or 'none'
+  # Use 'none' when providing a completely custom webpack configuration
+  # Note: When using rspack, swc is used automatically regardless of this setting
+  javascript_transpiler: "swc"
+
+  # Select assets bundler to use
+  # Available options: 'webpack' (default) or 'rspack'
+  assets_bundler: "webpack"
+
+  # Path to the directory containing webpack/rspack config files
+  # Defaults to 'config/webpack' for webpack or 'config/rspack' for rspack
+  # Use '.' to specify the root directory of your project
+  # assets_bundler_config_path: config/webpack
+
+  # Hook to run before webpack compilation (e.g., for generating dynamic entry points)
+  # SECURITY: Only reference trusted scripts within your project. The hook command will be
+  # validated to ensure it points to a file within the project root.
+  # Example: precompile_hook: 'bin/shakapacker-precompile-hook'
+  precompile_hook: 'bin/shakapacker-precompile-hook'
+  # Raises an error if there is a mismatch in the shakapacker gem and npm package being used
+  ensure_consistent_versioning: true
+
+  # Select whether the compiler will use SHA digest ('digest' option) or most recent modified timestamp ('mtime') to determine freshness
+  compiler_strategy: digest
+
+  # Select whether the compiler will always use a content hash and not just in production
+  # Content hashes are recommended for production cache busting
+  useContentHash: true
+
+  # Setting the asset host here will override Rails.application.config.asset_host.
+  # Here, you can set different asset_host per environment. Note that
+  # SHAKAPACKER_ASSET_HOST will override both configurations.
+  # asset_host: custom-path
+
+  # Utilizing webpack-subresource-integrity plugin, will generate integrity hashes for all entries in manifest.json
+  # https://github.com/waysact/webpack-subresource-integrity/tree/main/webpack-subresource-integrity
+  integrity:
+    enabled: false
+    # Which cryptographic function(s) to use, for generating the integrity hash(es). Default sha-384. Other possible values sha256, sha512
+    hash_functions: ["sha384"]
+    # Default "anonymous". Other possible value "use-credentials"
+    # https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#cross-origin_resource_sharing_and_subresource_integrity
+    cross_origin: "anonymous"
+
+  # HTTP 103 Early Hints support for faster asset loading
+  # Sends Link headers to browsers so they can preload assets while Rails is rendering
+  # See docs/early_hints_new_api.md for setup instructions and requirements
+  # https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-send_early_hints
+  early_hints:
+    enabled: false
+    # css: "preload" # 'preload' | 'prefetch' | 'none' - default: 'preload'
+    # js: "preload" # 'preload' | 'prefetch' | 'none' - default: 'preload'
+    # debug: false # Output early hints info as HTML comments for troubleshooting
+
+development:
+  <<: *default
+  compile: true
+  compiler_strategy: mtime
+
+  # Disable content hashes in development for faster builds
+  # https://webpack.js.org/guides/caching/
+  useContentHash: false
+
+  # Early hints disabled by default in development
+  # To enable: Set enabled: true AND start Puma with: bundle exec puma --early-hints
+  # See docs/early_hints_new_api.md for setup instructions
+  # early_hints:
+  #   enabled: true
+  #   css: "preload"
+  #   js: "preload"
+  #   debug: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  # Keys not described there are documented inline and in https://github.com/shakacode/shakapacker/
+  dev_server:
+    # For running dev server with https, set `server: https`.
+    # server: https
+
+    host: localhost
+    port: 3035
+    # Hot Module Replacement updates modules while the application is running without a full reload
+    # Used instead of the `hot` key in https://webpack.js.org/configuration/dev-server/#devserverhot
+    hmr: false
+    # If HMR is on, CSS will be inlined by delivering it as part of the script payload via style-loader. Be sure
+    # that you add style-loader to your project dependencies.
+    #
+    # If you want to instead deliver CSS via <link> with the mini-css-extract-plugin, set inline_css to false.
+    # In that case, style-loader is not needed as a dependency.
+    #
+    # mini-css-extract-plugin is a required dependency in both cases.
+    inline_css: true
+    # Defaults to the inverse of hmr. Uncomment to manually set this.
+    # live_reload: true
+    client:
+      # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
+      overlay: true
+      # May also be a string
+      # webSocketURL:
+      #  hostname: '0.0.0.0'
+      #  pathname: '/ws'
+      #  port: 8080
+    # Should we use gzip compression?
+    compress: true
+    # Note that apps that do not check the host are vulnerable to DNS rebinding attacks
+    allowed_hosts: "auto"
+    # Shows progress and colorizes output of bin/shakapacker[-dev-server]
+    pretty: true
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    static:
+      watch:
+        ignored: "**/node_modules/**"
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+  # Early hints disabled by default. See docs/early_hints_new_api.md before enabling.
+  # Requires proper server configuration (Puma + HTTP/2 proxy like nginx, Thruster, or Control Plane)
+  early_hints:
+    enabled: false
+    # css: "preload"
+    # js: "preload"
+    # debug: false

--- a/config/webpack/ServerClientOrBoth.js
+++ b/config/webpack/ServerClientOrBoth.js
@@ -1,0 +1,51 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/config/webpack/ServerClientOrBoth.js
+
+const clientWebpackConfig = require('./clientWebpackConfig');
+const { default: serverWebpackConfig } = require('./serverWebpackConfig');
+const rscWebpackConfig = require('./rscWebpackConfig');
+
+const serverClientOrBoth = (envSpecific) => {
+  const clientConfig = clientWebpackConfig();
+  const serverConfig = serverWebpackConfig();
+
+  const rscConfig = rscWebpackConfig();
+
+
+  if (envSpecific) {
+
+    envSpecific(clientConfig, serverConfig, rscConfig);
+
+  }
+
+  let result;
+  // For HMR, need to separate the the client and server webpack configurations
+  if (process.env.WEBPACK_SERVE || process.env.CLIENT_BUNDLE_ONLY) {
+    // eslint-disable-next-line no-console
+    console.log('[React on Rails] Creating only the client bundles.');
+    result = clientConfig;
+  } else if (process.env.SERVER_BUNDLE_ONLY) {
+    // eslint-disable-next-line no-console
+    console.log('[React on Rails] Creating only the server bundle.');
+    result = serverConfig;
+
+  } else if (process.env.RSC_BUNDLE_ONLY) {
+    // eslint-disable-next-line no-console
+    console.log('[React on Rails] Creating only the RSC bundle.');
+    result = rscConfig;
+
+  } else {
+    // default is the standard client and server build
+    // eslint-disable-next-line no-console
+
+    console.log('[React on Rails] Creating client, server, and RSC bundles.');
+    result = [clientConfig, serverConfig, rscConfig];
+
+  }
+
+  // To debug, uncomment next line and inspect "result"
+  // debugger
+  return result;
+};
+
+module.exports = serverClientOrBoth;

--- a/config/webpack/clientWebpackConfig.js
+++ b/config/webpack/clientWebpackConfig.js
@@ -1,0 +1,22 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/config/webpack/clientWebpackConfig.js
+
+const commonWebpackConfig = require('./commonWebpackConfig');
+const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
+
+const configureClient = () => {
+  const clientConfig = commonWebpackConfig();
+
+  // server-bundle is special and should ONLY be built by the serverConfig
+  // In case this entry is not deleted, a very strange "window" not found
+  // error shows referring to window["webpackJsonp"]. That is because the
+  // client config is going to try to load chunks.
+  delete clientConfig.entry['server-bundle'];
+
+  // Add React Server Components plugin for client bundle
+  clientConfig.plugins.push(new RSCWebpackPlugin({ isServer: false }));
+
+  return clientConfig;
+};
+
+module.exports = configureClient;

--- a/config/webpack/commonWebpackConfig.js
+++ b/config/webpack/commonWebpackConfig.js
@@ -1,0 +1,18 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/config/webpack/commonWebpackConfig.js
+
+// Common configuration applying to client and server configuration
+const { generateWebpackConfig, merge } = require('shakapacker');
+
+const baseClientWebpackConfig = generateWebpackConfig();
+
+const commonOptions = {
+  resolve: {
+    extensions: ['.css', '.ts', '.tsx'],
+  },
+};
+
+// Copy the object using merge b/c the baseClientWebpackConfig and commonOptions are mutable globals
+const commonWebpackConfig = () => merge({}, baseClientWebpackConfig, commonOptions);
+
+module.exports = commonWebpackConfig;

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,0 +1,28 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/config/webpack/development.js
+
+const { devServer, inliningCss, config } = require('shakapacker');
+
+const serverClientOrBoth = require('./ServerClientOrBoth');
+
+const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
+  // React Refresh (Fast Refresh) setup - only when dev server is running (HMR mode)
+  if (process.env.WEBPACK_SERVE) {
+    // eslint-disable-next-line global-require
+    if (config.assets_bundler === 'rspack') {
+      // Rspack uses @rspack/plugin-react-refresh for React Fast Refresh
+      const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
+      clientWebpackConfig.plugins.push(new ReactRefreshPlugin());
+    } else {
+      // Webpack uses @pmmmwh/react-refresh-webpack-plugin
+      const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+      clientWebpackConfig.plugins.push(
+        new ReactRefreshWebpackPlugin({
+          // Use default overlay configuration for better compatibility
+        }),
+      );
+    }
+  }
+};
+
+module.exports = serverClientOrBoth(developmentEnvOnly);

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,0 +1,10 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/config/webpack/production.js
+
+const serverClientOrBoth = require('./ServerClientOrBoth');
+
+const productionEnvOnly = (_clientWebpackConfig, _serverWebpackConfig) => {
+  // place any code here that is for production only
+};
+
+module.exports = serverClientOrBoth(productionEnvOnly);

--- a/config/webpack/rscWebpackConfig.js
+++ b/config/webpack/rscWebpackConfig.js
@@ -1,0 +1,79 @@
+// React Server Components webpack configuration
+// This creates the RSC bundle based on the server webpack config
+// See: https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/
+
+const serverWebpackModule = require('./serverWebpackConfig');
+
+// Backward compatibility:
+// - New Pro config exports: { default: configureServer, extractLoader }
+// - Legacy config exports: module.exports = configureServer
+const serverWebpackConfig = serverWebpackModule.default || serverWebpackModule;
+const extractLoader = serverWebpackModule.extractLoader || ((rule, loaderName) => {
+  if (!Array.isArray(rule.use)) return null;
+  return rule.use.find((item) => {
+    const testValue = typeof item === 'string' ? item : item.loader;
+    return testValue && testValue.includes(loaderName);
+  });
+});
+
+const configureRsc = () => {
+  // Pass true to skip RSCWebpackPlugin - RSC bundle doesn't need it
+  const rscConfig = serverWebpackConfig(true);
+
+  // Update the entry name to be `rsc-bundle` instead of `server-bundle`
+  const rscEntry = {
+    'rsc-bundle': rscConfig.entry['server-bundle'],
+  };
+  rscConfig.entry = rscEntry;
+
+  // Add the RSC loader after the JS loader (babel-loader or swc-loader)
+  // Webpack processes loaders right-to-left, so pushing to end means
+  // WebpackLoader runs first — it sees raw source with 'use client' directives
+  // and replaces client components with registerClientReference proxies.
+  const { rules } = rscConfig.module;
+  rules.forEach((rule) => {
+    if (typeof rule.use === 'function') {
+      // Shakapacker with SWC defines rule.use as a function that dynamically
+      // returns the loader config per-file. Wrap it to append the RSC loader.
+      const sampleResult = rule.use({ resource: 'test.jsx' });
+      const sampleLoader = typeof sampleResult === 'string' ? sampleResult : sampleResult?.loader;
+      if (sampleLoader && (sampleLoader.includes('swc-loader') || sampleLoader.includes('babel-loader'))) {
+        const originalUse = rule.use;
+        rule.use = (info) => {
+          const result = originalUse(info);
+          const loaders = Array.isArray(result) ? result : [result];
+          return [...loaders, { loader: 'react-on-rails-rsc/WebpackLoader' }];
+        };
+      }
+    } else if (Array.isArray(rule.use)) {
+      // Babel uses a static array for rule.use
+      const jsLoader = extractLoader(rule, 'babel-loader') || extractLoader(rule, 'swc-loader');
+      if (jsLoader) {
+        rule.use.push({
+          loader: 'react-on-rails-rsc/WebpackLoader',
+        });
+      }
+    }
+  });
+
+  // Add the `react-server` condition to the resolve config
+  // This condition is used by React and React on Rails to identify RSC bundles
+  // The `...` tells webpack to retain the default conditions (e.g., `node` for server target)
+  rscConfig.resolve = {
+    ...rscConfig.resolve,
+    conditionNames: ['react-server', '...'],
+    alias: {
+      ...rscConfig.resolve?.alias,
+      // Ignore react-dom/server in RSC bundle - it's not needed for RSC payload generation
+      // Not removing it will cause a runtime error
+      'react-dom/server': false,
+    },
+  };
+
+  // Update the output bundle name to be `rsc-bundle.js` instead of `server-bundle.js`
+  rscConfig.output.filename = 'rsc-bundle.js';
+
+  return rscConfig;
+};
+
+module.exports = configureRsc;

--- a/config/webpack/serverWebpackConfig.js
+++ b/config/webpack/serverWebpackConfig.js
@@ -1,0 +1,161 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/config/webpack/serverWebpackConfig.js
+
+const { merge, config } = require('shakapacker');
+const commonWebpackConfig = require('./commonWebpackConfig');
+
+const bundler = config.assets_bundler === 'rspack'
+  ? require('@rspack/core')
+  : require('webpack');
+const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
+
+function extractLoader(rule, loaderName) {
+  if (!Array.isArray(rule.use)) return null;
+  return rule.use.find((item) => {
+    const testValue = typeof item === 'string' ? item : item.loader;
+    return testValue && testValue.includes(loaderName);
+  });
+}
+
+// rscBundle parameter: when true, skips RSCWebpackPlugin (RSC bundle doesn't need it)
+const configureServer = (rscBundle = false) => {
+  // We need to use "merge" because the clientConfigObject, EVEN after running
+  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
+  // entry value will result in changing the client config!
+  // Using webpack-merge into an empty object avoids this issue.
+  const serverWebpackConfig = commonWebpackConfig();
+
+  // We just want the single server bundle entry
+  const serverEntry = {
+    'server-bundle': serverWebpackConfig.entry['server-bundle'],
+  };
+
+  if (!serverEntry['server-bundle']) {
+    throw new Error(
+      "Create a pack with the file name 'server-bundle.js' containing all the server rendering files",
+    );
+  }
+
+  serverWebpackConfig.entry = serverEntry;
+
+  // Remove the mini-css-extract-plugin from the style loaders because
+  // the client build will handle exporting CSS.
+  // replace file-loader with null-loader
+  serverWebpackConfig.module.rules.forEach((loader) => {
+    if (loader.use && loader.use.filter) {
+      loader.use = loader.use.filter(
+        (item) => !(typeof item === 'string' && item.match(/mini-css-extract-plugin/)),
+      );
+    }
+  });
+
+  // No splitting of chunks for a server bundle
+  serverWebpackConfig.optimization = {
+    minimize: false,
+  };
+  // Add RSC plugin for server bundle (handles client component references)
+  // Skip for RSC bundle - it doesn't need RSCWebpackPlugin
+  if (!rscBundle) {
+    serverWebpackConfig.plugins.push(new RSCWebpackPlugin({ isServer: true }));
+  }
+  serverWebpackConfig.plugins.unshift(new bundler.optimize.LimitChunkCountPlugin({ maxChunks: 1 }));
+
+  // Custom output for the server-bundle
+  // Using Shakapacker 9.0+ privateOutputPath for automatic sync with shakapacker.yml
+  // This eliminates manual path configuration and keeps configs in sync.
+  // Falls back to hardcoded path if private_output_path is not configured.
+  const serverBundleOutputPath = config.privateOutputPath ||
+    require('path').resolve(__dirname, '../../ssr-generated');
+
+  serverWebpackConfig.output = {
+    filename: 'server-bundle.js',
+    globalObject: 'this',
+    // Required for React on Rails Pro Node Renderer
+    libraryTarget: 'commonjs2',
+    path: serverBundleOutputPath,
+    // No publicPath needed since server bundles are not served via web
+    // https://webpack.js.org/configuration/output/#outputglobalobject
+  };
+
+  // Validate server bundle output path configuration
+  // For Shakapacker 9.0+, verify privateOutputPath is configured in shakapacker.yml
+  if (!config.privateOutputPath) {
+    console.warn('⚠️  Shakapacker 9.0+ detected but private_output_path not configured in shakapacker.yml');
+    console.warn('   Add to config/shakapacker.yml:');
+    console.warn('     private_output_path: ssr-generated');
+    console.warn('   Run: rails react_on_rails:doctor to validate your configuration');
+  }
+
+
+  // Don't hash the server bundle b/c would conflict with the client manifest
+  // And no need for the MiniCssExtractPlugin
+  serverWebpackConfig.plugins = serverWebpackConfig.plugins.filter(
+    (plugin) =>
+      plugin.constructor.name !== 'WebpackAssetsManifest' &&
+      plugin.constructor.name !== 'MiniCssExtractPlugin' &&
+      plugin.constructor.name !== 'ForkTsCheckerWebpackPlugin',
+  );
+
+  // Configure loader rules for SSR
+  // Remove the mini-css-extract-plugin from the style loaders because
+  // the client build will handle exporting CSS.
+  // replace file-loader with null-loader
+  const rules = serverWebpackConfig.module.rules;
+  rules.forEach((rule) => {
+    if (Array.isArray(rule.use)) {
+      // remove the mini-css-extract-plugin and style-loader
+      rule.use = rule.use.filter((item) => {
+        let testValue;
+        if (typeof item === 'string') {
+          testValue = item;
+        } else if (typeof item.loader === 'string') {
+          testValue = item.loader;
+        }
+        return !(testValue.match(/mini-css-extract-plugin/) || testValue === 'style-loader');
+      });
+      const cssLoader = rule.use.find((item) => {
+        let testValue;
+
+        if (typeof item === 'string') {
+          testValue = item;
+        } else if (typeof item.loader === 'string') {
+          testValue = item.loader;
+        }
+
+        return testValue.includes('css-loader');
+      });
+      if (cssLoader && cssLoader.options) {
+        cssLoader.options.modules = { exportOnlyLocals: true };
+      }
+
+      // Set SSR caller for Babel (if using Babel instead of SWC)
+      const babelLoader = extractLoader(rule, 'babel-loader');
+      if (babelLoader && babelLoader.options) {
+        babelLoader.options.caller = { ssr: true };
+      }
+
+      // Skip writing image files during SSR by setting emitFile to false
+    } else if (rule.use && (rule.use.loader === 'url-loader' || rule.use.loader === 'file-loader')) {
+      rule.use.options.emitFile = false;
+    }
+  });
+
+  // eval works well for the SSR bundle because it's the fastest and shows
+  // lines in the server bundle which is good for debugging SSR
+  // The default of cheap-module-source-map is slow and provides poor info.
+  serverWebpackConfig.devtool = 'eval';
+
+  // React on Rails Pro uses Node renderer, so target must be 'node'
+  // This fixes issues with libraries like Emotion and loadable-components
+  serverWebpackConfig.target = 'node';
+
+  // Disable Node.js polyfills - not needed when targeting Node
+  serverWebpackConfig.node = false;
+
+  return serverWebpackConfig;
+};
+
+module.exports = {
+  default: configureServer,
+  extractLoader,
+};

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,0 +1,10 @@
+// The source code including full typescript support is available at: 
+// https://github.com/shakacode/react_on_rails_demo_ssr_hmr/blob/master/config/webpack/test.js
+
+const serverClientOrBoth = require('./ServerClientOrBoth')
+
+const testOnly = (_clientWebpackConfig, _serverWebpackConfig) => {
+  // place any code here that is for test only
+}
+
+module.exports = serverClientOrBoth(testOnly)

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -1,0 +1,15 @@
+const { env } = require('shakapacker')
+const { existsSync } = require('fs')
+const { resolve } = require('path')
+
+const envSpecificConfig = () => {
+  const path = resolve(__dirname, `${env.nodeEnv}.js`)
+  if (existsSync(path)) {
+    console.log(`Loading ENV specific webpack configuration file ${path}`)
+    return require(path)
+  } else {
+    throw new Error(`Could not find file to load ${path}, based on NODE_ENV`)
+  }
+}
+
+module.exports = envSpecificConfig()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "packageManager": "npm@10.8.2",
+  "name": "app",
+  "private": true,
+  "version": "0.1.0",
+  "browserslist": [
+    "defaults"
+  ],
+  "dependencies": {
+    "compression-webpack-plugin": "^11.1.0",
+    "css-loader": "7.1.4",
+    "css-minimizer-webpack-plugin": "7.0.4",
+    "mini-css-extract-plugin": "2.10.0",
+    "prop-types": "15.8.1",
+    "react": "19.0.4",
+    "react-dom": "19.0.4",
+    "react-on-rails-pro": "16.4.0-rc.3",
+    "react-on-rails-pro-node-renderer": "16.4.0-rc.3",
+    "react-on-rails-rsc": "19.0.4",
+    "sass-loader": "^16.0.7",
+    "shakapacker": "9.5.0",
+    "style-loader": "4.0.0",
+    "terser-webpack-plugin": "^5.3.16",
+    "webpack": "^5.105.2",
+    "webpack-assets-manifest": "^6.5.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-merge": "^6.0.1",
+    "webpack-subresource-integrity": "^5.1.0"
+  },
+  "devDependencies": {
+    "@pmmmwh/react-refresh-webpack-plugin": "0.6.2",
+    "@swc/core": "1.15.11",
+    "react-refresh": "0.18.0",
+    "swc-loader": "0.2.7",
+    "webpack-dev-server": "^5.2.3"
+  }
+}


### PR DESCRIPTION
## Summary
- Set up React on Rails Pro with RSC support using the `--rsc` generator
- Implement all 5 component tree restructuring patterns from the migration guide
- Fix RSC WebpackLoader not running with SWC transpiler (Shakapacker's SWC rule uses a function for `rule.use`, not an array)
- Add client `application.js` entry point for Shakapacker pack tag rendering
- Add home page with links to all patterns

## Patterns Implemented
1. **Push State to Leaf** — ProductPage (server) + AddToCartButton (client)
2. **Donut Pattern** — Modal (client wrapper) + Cart (server children)
3. **State Wrapper** — ColorProvider (client) + Header/MainContent/Footer (server)
4. **Async Suspense** — Dashboard with independent Suspense boundaries
5. **Promise Handoff** — BlogPost (server await) + Comments (client `use()`)

## Bugs Found & Fixed
- **RSC WebpackLoader not applied with SWC**: `rscWebpackConfig.js` only checked `Array.isArray(rule.use)` but Shakapacker's SWC rule defines `rule.use` as a function. Added handling for function-based `rule.use`.
- **Missing client hydration**: `append_javascript_pack_tag` queued packs but no `javascript_pack_tag` in the layout rendered them. Created `application.js` entry point.

Closes #1

## Test plan
- [ ] Run `bin/dev` and visit each pattern page
- [ ] Verify client interactivity (Add to Cart button, Modal open/close, theme toggle, comment likes)
- [ ] Verify RSC bundle has no `useState` warnings (client components replaced with `registerClientReference`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)