### PR TITLE
Add ref behavior test pages for Server Components

### DIFF
--- a/app/controllers/patterns_controller.rb
+++ b/app/controllers/patterns_controller.rb
@@ -44,4 +44,19 @@ class PatternsController < ApplicationController
   def memo_forward_ref
     stream_view_containing_react_components(template: "patterns/memo_forward_ref")
   end
+
+  # Ref tests: what works
+  def ref_working
+    stream_view_containing_react_components(template: "patterns/ref_working")
+  end
+
+  # Ref tests: passing ref to Server Component (should crash)
+  def ref_crash
+    stream_view_containing_react_components(template: "patterns/ref_crash")
+  end
+
+  # Ref tests: passing ref from Server to Client Component (should crash)
+  def ref_to_client_crash
+    stream_view_containing_react_components(template: "patterns/ref_to_client_crash")
+  end
 end

--- a/app/javascript/src/RefTests/components/RefCrash.jsx
+++ b/app/javascript/src/RefTests/components/RefCrash.jsx
@@ -1,0 +1,55 @@
+// Test: What CRASHES with ref in Server Components
+//
+// The React Flight serializer explicitly throws:
+//   "Refs cannot be used in Server Components, nor passed to Client Components."
+//
+// This page demonstrates the crash by passing a ref to a server component element.
+// If you see this page render, the crash didn't happen (which would be surprising).
+// Expected: the page shows an error.
+
+import React from 'react';
+
+function ServerChild({ ref, label }) {
+  return (
+    <div style={{ padding: 16, border: '1px solid #ccc', borderRadius: 8 }}>
+      <strong>{label}</strong>
+      <p>ref value: {JSON.stringify(ref)}</p>
+    </div>
+  );
+}
+
+const RefCrash = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  // This creates a ref object
+  const myRef = React.createRef();
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 700, margin: '0 auto' }}>
+      <h1>Ref Crash Test</h1>
+
+      <div style={{
+        background: '#ffebee',
+        border: '1px solid #ef9a9a',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 24,
+        fontSize: '0.85em',
+      }}>
+        This page attempts to pass a <code>ref</code> prop to a Server Component element.
+        The Flight serializer should throw: <em>&quot;Refs cannot be used in Server
+        Components, nor passed to Client Components.&quot;</em>
+      </div>
+
+      {/* This line should crash the Flight serializer */}
+      <ServerChild ref={myRef} label="I should not render" />
+
+      {/* If we get here, the crash didn't happen */}
+      <p style={{ color: '#2e7d32', fontWeight: 'bold' }}>
+        If you see this text, passing ref to a Server Component did NOT crash.
+      </p>
+    </div>
+  );
+};
+
+export default RefCrash;

--- a/app/javascript/src/RefTests/components/RefToClientCrash.jsx
+++ b/app/javascript/src/RefTests/components/RefToClientCrash.jsx
@@ -1,0 +1,45 @@
+// Test: Can we pass ref from a Server Component to a Client Component?
+//
+// The Flight serializer checks ref BEFORE determining if the target is
+// a client or server component. So this should also crash with:
+//   "Refs cannot be used in Server Components, nor passed to Client Components."
+
+import React from 'react';
+import Modal from '../../CartPage/components/Modal';
+
+const RefToClientCrash = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  const myRef = React.createRef();
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 700, margin: '0 auto' }}>
+      <h1>Ref to Client Component Crash Test</h1>
+
+      <div style={{
+        background: '#ffebee',
+        border: '1px solid #ef9a9a',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 24,
+        fontSize: '0.85em',
+      }}>
+        This page attempts to pass a <code>ref</code> from a Server Component to a
+        Client Component (<code>Modal</code>). The Flight serializer should throw the
+        same error — it checks ref <strong>before</strong> it checks whether the target
+        is a client reference.
+      </div>
+
+      {/* This should crash — ref check happens before client component detection */}
+      <Modal ref={myRef}>
+        <p>I should not render</p>
+      </Modal>
+
+      <p style={{ color: '#2e7d32', fontWeight: 'bold' }}>
+        If you see this text, passing ref to a Client Component did NOT crash.
+      </p>
+    </div>
+  );
+};
+
+export default RefToClientCrash;

--- a/app/javascript/src/RefTests/components/RefWorking.jsx
+++ b/app/javascript/src/RefTests/components/RefWorking.jsx
@@ -1,0 +1,134 @@
+// Test: What works with ref in Server Components
+//
+// React 19 made ref a regular prop and deprecated forwardRef.
+// But the Flight serializer explicitly REJECTS non-null refs.
+// This page shows what DOES work.
+
+import React from 'react';
+
+// Test 1: createRef() is available in the server runtime
+// (even though using the result as a ref prop would crash)
+const refObject = React.createRef();
+
+// Test 2: forwardRef wrapper works (as long as no ref is actually passed)
+const ForwardRefBox = React.forwardRef(function ForwardRefBox(props, ref) {
+  return (
+    <div
+      ref={ref}
+      style={{
+        padding: 16,
+        border: '2px solid #90caf9',
+        borderRadius: 8,
+        background: '#e3f2fd',
+      }}
+    >
+      <strong>forwardRef component:</strong> {props.label}
+    </div>
+  );
+});
+
+// Test 3: ref as a regular prop name (NOT React's special ref handling)
+// If you name the prop something other than "ref", it's just a normal prop
+function DisplayWithCustomRefProp({ myRef, children }) {
+  return (
+    <div style={{
+      padding: 16,
+      border: '2px solid #a5d6a7',
+      borderRadius: 8,
+      background: '#e8f5e9',
+    }}>
+      <strong>Custom ref-like prop:</strong> myRef = {JSON.stringify(myRef)}
+      <div>{children}</div>
+    </div>
+  );
+}
+
+const RefWorking = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 700, margin: '0 auto' }}>
+      <h1>Ref in Server Components: What Works</h1>
+
+      <div style={{
+        background: '#e8f5e9',
+        border: '1px solid #a5d6a7',
+        borderRadius: 8,
+        padding: 12,
+        marginBottom: 24,
+        fontSize: '0.85em',
+      }}>
+        These tests show ref-related features that <strong>do work</strong> in Server Components.
+        See the companion page for what <strong>crashes</strong>.
+      </div>
+
+      {/* Test 1 */}
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ color: '#1565c0' }}>Test 1: React.createRef() is available</h2>
+        <p>
+          <code>React.createRef()</code> is exported from the server React runtime.
+          Calling it produces a ref object:
+        </p>
+        <pre style={{
+          background: '#f5f5f5',
+          padding: 12,
+          borderRadius: 8,
+          overflow: 'auto',
+        }}>
+          {`React.createRef() = ${JSON.stringify(refObject)}`}
+        </pre>
+        <p style={{ color: '#2e7d32', fontWeight: 'bold', fontSize: '0.9em' }}>
+          createRef is available. But passing it as a ref prop to any element would crash.
+        </p>
+      </section>
+
+      {/* Test 2 */}
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ color: '#6a1b9a' }}>Test 2: forwardRef component (no ref passed)</h2>
+        <p>
+          A <code>React.forwardRef()</code> wrapper works as a Server Component, as long as
+          no actual <code>ref</code> is passed. The Flight serializer unwraps the forwardRef
+          and calls the inner render function directly.
+        </p>
+        <ForwardRefBox label="Rendered on the server without a ref" />
+        <p style={{ color: '#2e7d32', fontWeight: 'bold', fontSize: '0.9em' }}>
+          Works. forwardRef is just unwrapped — the inner function renders normally.
+        </p>
+      </section>
+
+      {/* Test 3 */}
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ color: '#e65100' }}>Test 3: Custom prop named something other than &quot;ref&quot;</h2>
+        <p>
+          Only the literal prop name <code>ref</code> is special to React.
+          A prop named <code>myRef</code> is just a regular serializable prop.
+        </p>
+        <DisplayWithCustomRefProp myRef="some-string-id">
+          This works because &quot;myRef&quot; is not React&apos;s special ref prop.
+        </DisplayWithCustomRefProp>
+        <p style={{ color: '#2e7d32', fontWeight: 'bold', fontSize: '0.9em' }}>
+          Works. Only the literal name &quot;ref&quot; is checked by the Flight serializer.
+        </p>
+      </section>
+
+      <hr style={{ margin: '24px 0', border: 'none', borderTop: '1px solid #e0e0e0' }} />
+
+      <div style={{ fontSize: '0.9em', color: '#555' }}>
+        <strong>Summary:</strong> <code>createRef()</code> and <code>forwardRef()</code> are
+        available in the server runtime, but actually passing a non-null <code>ref</code> prop
+        to any element throws: <em>&quot;Refs cannot be used in Server Components, nor passed
+        to Client Components.&quot;</em>
+      </div>
+
+      <p style={{ marginTop: 16 }}>
+        <a href="/patterns/ref_crash" style={{ color: '#c62828' }}>
+          See what crashes →
+        </a>
+        {' | '}
+        <a href="/" style={{ color: '#1976d2' }}>Back to home</a>
+      </p>
+    </div>
+  );
+};
+
+export default RefWorking;

--- a/app/javascript/src/RefTests/ror_components/RefCrash.jsx
+++ b/app/javascript/src/RefTests/ror_components/RefCrash.jsx
@@ -1,0 +1,3 @@
+import RefCrash from '../components/RefCrash';
+
+export default RefCrash;

--- a/app/javascript/src/RefTests/ror_components/RefToClientCrash.jsx
+++ b/app/javascript/src/RefTests/ror_components/RefToClientCrash.jsx
@@ -1,0 +1,3 @@
+import RefToClientCrash from '../components/RefToClientCrash';
+
+export default RefToClientCrash;

--- a/app/javascript/src/RefTests/ror_components/RefWorking.jsx
+++ b/app/javascript/src/RefTests/ror_components/RefWorking.jsx
@@ -1,0 +1,3 @@
+import RefWorking from '../components/RefWorking';
+
+export default RefWorking;

--- a/app/views/patterns/ref_crash.html.erb
+++ b/app/views/patterns/ref_crash.html.erb
@@ -1,0 +1,1 @@
+<%= stream_react_component('RefCrash', props: {}, prerender: true) %>

--- a/app/views/patterns/ref_to_client_crash.html.erb
+++ b/app/views/patterns/ref_to_client_crash.html.erb
@@ -1,0 +1,1 @@
+<%= stream_react_component('RefToClientCrash', props: {}, prerender: true) %>

--- a/app/views/patterns/ref_working.html.erb
+++ b/app/views/patterns/ref_working.html.erb
@@ -1,0 +1,1 @@
+<%= stream_react_component('RefWorking', props: {}, prerender: true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
   get 'patterns/dashboard', to: 'patterns#dashboard'         # Pattern 4
   get 'patterns/blog_post', to: 'patterns#blog_post'         # Pattern 5
   get 'patterns/memo_forward_ref', to: 'patterns#memo_forward_ref'  # Issue #2502 test
+  get 'patterns/ref_working', to: 'patterns#ref_working'            # Ref: what works
+  get 'patterns/ref_crash', to: 'patterns#ref_crash'                # Ref: crash on SC
+  get 'patterns/ref_to_client_crash', to: 'patterns#ref_to_client_crash'  # Ref: crash on CC
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Summary
- Add 3 test pages investigating how `ref` works with React Server Components in React 19
- React 19 made `ref` a regular prop, but the Flight serializer explicitly rejects non-null refs

## Test Pages
1. **`/patterns/ref_working`** — What works:
   - `React.createRef()` is available in server runtime
   - `React.forwardRef()` wrapper works (no actual ref passed)
   - Custom prop names like `myRef` are fine
2. **`/patterns/ref_crash`** — Passes `ref` to a Server Component element → crashes
3. **`/patterns/ref_to_client_crash`** — Passes `ref` from Server to Client Component → crashes

## Findings
The Flight serializer in `renderElement()` has an explicit check:
```js
if (null !== ref && void 0 !== ref)
    throw Error("Refs cannot be used in Server Components, nor passed to Client Components.");
```
This runs **before** type discrimination, so it blocks refs on both server and client component elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)